### PR TITLE
fix(router): allow surplus from swap when routing intents

### DIFF
--- a/src/Router.sol
+++ b/src/Router.sol
@@ -92,13 +92,26 @@ contract Router is
     mapping(uint256 => uint256) public chainWithdrawGasLimits;
 
     // Event emitted when an intent contract is set
-    event IntentContractSet(uint256 indexed chainId, address indexed intentContract);
+    event IntentContractSet(
+        uint256 indexed chainId,
+        address indexed intentContract
+    );
     // Event emitted when a new token is added
     event TokenAdded(string indexed name);
     // Event emitted when a token association is added
-    event TokenAssociationAdded(string indexed name, uint256 indexed chainId, address asset, address zrc20);
+    event TokenAssociationAdded(
+        string indexed name,
+        uint256 indexed chainId,
+        address asset,
+        address zrc20
+    );
     // Event emitted when a token association is updated
-    event TokenAssociationUpdated(string indexed name, uint256 indexed chainId, address asset, address zrc20);
+    event TokenAssociationUpdated(
+        string indexed name,
+        uint256 indexed chainId,
+        address asset,
+        address zrc20
+    );
     // Event emitted when a token association is removed
     event TokenAssociationRemoved(string indexed name, uint256 indexed chainId);
     // Event emitted when an intent settlement is forwarded
@@ -111,9 +124,15 @@ contract Router is
         uint256 tip
     );
     // Event emitted when the gateway is updated
-    event GatewayUpdated(address indexed oldGateway, address indexed newGateway);
+    event GatewayUpdated(
+        address indexed oldGateway,
+        address indexed newGateway
+    );
     // Event emitted when the swap module is updated
-    event SwapModuleUpdated(address indexed oldSwapModule, address indexed newSwapModule);
+    event SwapModuleUpdated(
+        address indexed oldSwapModule,
+        address indexed newSwapModule
+    );
     // Event emitted when the global withdraw gas limit is updated
     event WithdrawGasLimitUpdated(uint256 oldGasLimit, uint256 newGasLimit);
     // Event emitted when a chain-specific withdraw gas limit is set
@@ -131,7 +150,10 @@ contract Router is
      * @param _gateway The address of the gateway contract
      * @param _swapModule The address of the swap module contract
      */
-    function initialize(address _gateway, address _swapModule) public initializer {
+    function initialize(
+        address _gateway,
+        address _swapModule
+    ) public initializer {
         __AccessControl_init();
         __UUPSUpgradeable_init_unchained();
         __Pausable_init_unchained();
@@ -153,7 +175,9 @@ contract Router is
      * @dev Function that authorizes an upgrade, can only be called by an account with the admin role
      * @param newImplementation Address of the new implementation
      */
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
     /**
      * @dev Pauses the contract, preventing onCall operations
@@ -174,7 +198,9 @@ contract Router is
      * @dev Updates the gateway address
      * @param _gateway New gateway address
      */
-    function updateGateway(address _gateway) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function updateGateway(
+        address _gateway
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_gateway != address(0), "Gateway cannot be zero address");
         emit GatewayUpdated(gateway, _gateway);
         gateway = _gateway;
@@ -184,8 +210,13 @@ contract Router is
      * @dev Updates the swap module address
      * @param _swapModule New swap module address
      */
-    function updateSwapModule(address _swapModule) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_swapModule != address(0), "Swap module cannot be zero address");
+    function updateSwapModule(
+        address _swapModule
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(
+            _swapModule != address(0),
+            "Swap module cannot be zero address"
+        );
         emit SwapModuleUpdated(swapModule, _swapModule);
         swapModule = _swapModule;
     }
@@ -197,11 +228,11 @@ contract Router is
      * @param decimalsOut The decimal places of the destination token
      * @return The expected amount with the destination token's decimal precision
      */
-    function calculateExpectedAmount(uint256 amountIn, uint8 decimalsIn, uint8 decimalsOut)
-        public
-        pure
-        returns (uint256)
-    {
+    function calculateExpectedAmount(
+        uint256 amountIn,
+        uint8 decimalsIn,
+        uint8 decimalsOut
+    ) public pure returns (uint256) {
         // Input validation
         require(decimalsIn <= 30, "Source decimals too high");
         require(decimalsOut <= 30, "Destination decimals too high");
@@ -216,7 +247,11 @@ contract Router is
             uint256 scalingFactor = 10 ** (decimalsOut - decimalsIn);
 
             // Check for potential overflow before multiplication
-            require(amountIn == 0 || (type(uint256).max / amountIn) >= scalingFactor, "Decimal conversion overflow");
+            require(
+                amountIn == 0 ||
+                    (type(uint256).max / amountIn) >= scalingFactor,
+                "Decimal conversion overflow"
+            );
 
             return amountIn * scalingFactor;
         }
@@ -231,7 +266,8 @@ contract Router is
     modifier onlyGatewayOrIntent() {
         // Allow calls from gateway or registered intent contracts
         require(
-            msg.sender == gateway || intentContracts[block.chainid] == msg.sender,
+            msg.sender == gateway ||
+                intentContracts[block.chainid] == msg.sender,
             "Only gateway or intent contract can call this function"
         );
         _;
@@ -251,10 +287,12 @@ contract Router is
         bytes calldata payload
     ) external override onlyGatewayOrIntent whenNotPaused {
         // Decode intent payload
-        PayloadUtils.IntentPayload memory intentPayload = PayloadUtils.decodeIntentPayload(payload);
+        PayloadUtils.IntentPayload memory intentPayload = PayloadUtils
+            .decodeIntentPayload(payload);
 
         // Check if target chain is ZetaChain
-        bool isZetaChainDestination = intentPayload.targetChain == block.chainid;
+        bool isZetaChainDestination = intentPayload.targetChain ==
+            block.chainid;
 
         // Create intent information struct
         IntentInformation memory intentInfo = IntentInformation({
@@ -269,7 +307,9 @@ contract Router is
         SettlementInfo memory settlementInfo = _processIntent(intentInfo);
 
         // Convert receiver from bytes to address
-        address receiverAddress = PayloadUtils.bytesToAddress(intentPayload.receiver);
+        address receiverAddress = PayloadUtils.bytesToAddress(
+            intentPayload.receiver
+        );
 
         // Encode settlement payload
         bytes memory settlementPayload = PayloadUtils.encodeSettlementPayload(
@@ -320,23 +360,34 @@ contract Router is
      * @dev Internal function to process the intent, convert amounts, and returns the settlement info
      * @param intentInfo The struct containing all intent processing information
      */
-    function _processIntent(IntentInformation memory intentInfo)
-        internal
-        returns (SettlementInfo memory settlementInfo)
-    {
+    function _processIntent(
+        IntentInformation memory intentInfo
+    ) internal returns (SettlementInfo memory settlementInfo) {
         // Verify the call is coming from a registered intent contract
         require(
-            intentContracts[intentInfo.context.chainID] == intentInfo.context.senderEVM,
+            intentContracts[intentInfo.context.chainID] ==
+                intentInfo.context.senderEVM,
             "Call must be from intent contract"
         );
 
         // Get token association for target chain
-        (settlementInfo.targetAsset, settlementInfo.targetZRC20,) =
-            getTokenAssociation(intentInfo.zrc20, intentInfo.intentPayload.targetChain);
+        (
+            settlementInfo.targetAsset,
+            settlementInfo.targetZRC20,
+
+        ) = getTokenAssociation(
+            intentInfo.zrc20,
+            intentInfo.intentPayload.targetChain
+        );
 
         // Get intent contract on target chain
-        settlementInfo.intentContract = intentContracts[intentInfo.intentPayload.targetChain];
-        require(settlementInfo.intentContract != address(0), "Intent contract not set for target chain");
+        settlementInfo.intentContract = intentContracts[
+            intentInfo.intentPayload.targetChain
+        ];
+        require(
+            settlementInfo.intentContract != address(0),
+            "Intent contract not set for target chain"
+        );
 
         // Get decimals for source and target tokens
         uint8 sourceDecimals = IZRC20(intentInfo.zrc20).decimals();
@@ -345,15 +396,24 @@ contract Router is
         // Convert amounts to target token decimal representation
         uint256 wantedAmountWithTip;
         uint256 wantedTip;
-        (settlementInfo.wantedAmount, wantedTip, wantedAmountWithTip) = _convertAmountsForDecimals(
-            intentInfo.intentPayload.amount, intentInfo.amountWithTip, sourceDecimals, targetDecimals
+        (
+            settlementInfo.wantedAmount,
+            wantedTip,
+            wantedAmountWithTip
+        ) = _convertAmountsForDecimals(
+            intentInfo.intentPayload.amount,
+            intentInfo.amountWithTip,
+            sourceDecimals,
+            targetDecimals
         );
 
         // Get the appropriate gas limit for the target chain - use custom gas limit if provided, otherwise fallback to default
         if (intentInfo.intentPayload.gasLimit > 0) {
             settlementInfo.gasLimit = intentInfo.intentPayload.gasLimit;
         } else {
-            settlementInfo.gasLimit = _getChainGasLimit(intentInfo.intentPayload.targetChain);
+            settlementInfo.gasLimit = _getChainGasLimit(
+                intentInfo.intentPayload.targetChain
+            );
         }
 
         // Initialize gas fee variables
@@ -363,8 +423,9 @@ contract Router is
         // Only get gas fee if the destination is not ZetaChain
         if (!intentInfo.isZetaChainDestination) {
             // Get gas fee info from target ZRC20
-            (settlementInfo.gasZRC20, settlementInfo.gasFee) =
-                IZRC20(settlementInfo.targetZRC20).withdrawGasFeeWithGasLimit(settlementInfo.gasLimit);
+            (settlementInfo.gasZRC20, settlementInfo.gasFee) = IZRC20(
+                settlementInfo.targetZRC20
+            ).withdrawGasFeeWithGasLimit(settlementInfo.gasLimit);
         }
 
         settlementInfo.actualAmount = settlementInfo.wantedAmount;
@@ -377,7 +438,10 @@ contract Router is
         } else {
             // Approve swap module to spend tokens
             IERC20(intentInfo.zrc20).approve(swapModule, 0);
-            IERC20(intentInfo.zrc20).approve(swapModule, intentInfo.amountWithTip);
+            IERC20(intentInfo.zrc20).approve(
+                swapModule,
+                intentInfo.amountWithTip
+            );
 
             // Perform swap through swap module
             settlementInfo.amountWithTipOut = ISwap(swapModule).swap(
@@ -389,11 +453,14 @@ contract Router is
                 zrc20ToTokenName[intentInfo.zrc20]
             );
 
-            // Validate that swap result is not greater than expected amount
-            require(wantedAmountWithTip >= settlementInfo.amountWithTipOut, "Swap returned invalid amount");
-
             // Calculate slippage difference and adjust tip accordingly
-            uint256 slippageAndFeeCost = wantedAmountWithTip - settlementInfo.amountWithTipOut;
+            // If swap returns more than expected (surplus), slippageAndFeeCost will be 0
+            // Note: Surplus amounts are currently ignored as they are too small to handle
+            // This will be addressed in future updates
+            uint256 slippageAndFeeCost = wantedAmountWithTip >
+                settlementInfo.amountWithTipOut
+                ? wantedAmountWithTip - settlementInfo.amountWithTipOut
+                : 0;
 
             // Check if tip covers the slippage and fee costs
             if (wantedTip > slippageAndFeeCost) {
@@ -405,9 +472,14 @@ contract Router is
                 // Calculate how much remaining slippage to cover from the amount
                 uint256 remainingCost = slippageAndFeeCost - wantedTip;
                 // Ensure the amount is greater than the remaining cost, otherwise fail
-                require(settlementInfo.wantedAmount > remainingCost, "Amount insufficient to cover costs after tip");
+                require(
+                    settlementInfo.wantedAmount > remainingCost,
+                    "Amount insufficient to cover costs after tip"
+                );
                 // Reduce the actual amount by the remaining cost
-                settlementInfo.actualAmount = settlementInfo.wantedAmount - remainingCost;
+                settlementInfo.actualAmount =
+                    settlementInfo.wantedAmount -
+                    remainingCost;
             }
         }
 
@@ -432,7 +504,9 @@ contract Router is
         IERC20(zrc20).approve(intentContract, amount);
 
         // Create a MessageContext
-        IIntent.MessageContext memory intentContext = IIntent.MessageContext({sender: address(this)});
+        IIntent.MessageContext memory intentContext = IIntent.MessageContext({
+            sender: address(this)
+        });
 
         // Call the intent contract directly
         IIntent(intentContract).onCall(intentContext, settlementPayload);
@@ -460,7 +534,10 @@ contract Router is
         uint256 gasLimit
     ) internal {
         // Prepare call options with provided gas limit
-        IGateway.CallOptions memory callOptions = IGateway.CallOptions({gasLimit: gasLimit, isArbitraryCall: false});
+        IGateway.CallOptions memory callOptions = IGateway.CallOptions({
+            gasLimit: gasLimit,
+            isArbitraryCall: false
+        });
 
         // Prepare revert options
         IGateway.RevertOptions memory revertOptions = IGateway.RevertOptions({
@@ -479,7 +556,12 @@ contract Router is
 
         // Call gateway to withdraw and call intent contract
         IGateway(gateway).withdrawAndCall(
-            abi.encodePacked(intentContract), amount, targetZRC20, settlementPayload, callOptions, revertOptions
+            abi.encodePacked(intentContract),
+            amount,
+            targetZRC20,
+            settlementPayload,
+            callOptions,
+            revertOptions
         );
     }
 
@@ -498,10 +580,26 @@ contract Router is
         uint256 amountWithTip,
         uint8 sourceDecimals,
         uint8 targetDecimals
-    ) private pure returns (uint256 wantedAmount, uint256 wantedTip, uint256 wantedAmountWithTip) {
+    )
+        private
+        pure
+        returns (
+            uint256 wantedAmount,
+            uint256 wantedTip,
+            uint256 wantedAmountWithTip
+        )
+    {
         // Convert the individual amount and the total amount with tip
-        wantedAmount = calculateExpectedAmount(amount, sourceDecimals, targetDecimals);
-        wantedAmountWithTip = calculateExpectedAmount(amountWithTip, sourceDecimals, targetDecimals);
+        wantedAmount = calculateExpectedAmount(
+            amount,
+            sourceDecimals,
+            targetDecimals
+        );
+        wantedAmountWithTip = calculateExpectedAmount(
+            amountWithTip,
+            sourceDecimals,
+            targetDecimals
+        );
 
         // Calculate tip as the difference to maintain the invariant:
         // wantedAmount + wantedTip == wantedAmountWithTip
@@ -522,8 +620,14 @@ contract Router is
      * @param chainId The chain ID to set the intent contract for
      * @param intentContract The address of the intent contract
      */
-    function setIntentContract(uint256 chainId, address intentContract) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(intentContract != address(0), "Invalid intent contract address");
+    function setIntentContract(
+        uint256 chainId,
+        address intentContract
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(
+            intentContract != address(0),
+            "Invalid intent contract address"
+        );
         intentContracts[chainId] = intentContract;
         emit IntentContractSet(chainId, intentContract);
     }
@@ -541,7 +645,9 @@ contract Router is
      * @dev Adds a new supported token
      * @param name The name of the token (e.g., "USDC")
      */
-    function addToken(string calldata name) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function addToken(
+        string calldata name
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(bytes(name).length > 0, "Token name cannot be empty");
         require(!_supportedTokens[name], "Token already exists");
 
@@ -557,14 +663,19 @@ contract Router is
      * @param asset The ERC20 address on the source chain
      * @param zrc20 The ZRC20 address on ZetaChain
      */
-    function addTokenAssociation(string calldata name, uint256 chainId, address asset, address zrc20)
-        public
-        onlyRole(DEFAULT_ADMIN_ROLE)
-    {
+    function addTokenAssociation(
+        string calldata name,
+        uint256 chainId,
+        address asset,
+        address zrc20
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_supportedTokens[name], "Token does not exist");
         require(asset != address(0), "Invalid asset address");
         require(zrc20 != address(0), "Invalid ZRC20 address");
-        require(_tokenAssets[name][chainId] == address(0), "Association already exists");
+        require(
+            _tokenAssets[name][chainId] == address(0),
+            "Association already exists"
+        );
 
         _tokenAssets[name][chainId] = asset;
         _tokenZrc20s[name][chainId] = zrc20;
@@ -581,14 +692,19 @@ contract Router is
      * @param asset The new ERC20 address on the source chain
      * @param zrc20 The new ZRC20 address on ZetaChain
      */
-    function updateTokenAssociation(string calldata name, uint256 chainId, address asset, address zrc20)
-        public
-        onlyRole(DEFAULT_ADMIN_ROLE)
-    {
+    function updateTokenAssociation(
+        string calldata name,
+        uint256 chainId,
+        address asset,
+        address zrc20
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_supportedTokens[name], "Token does not exist");
         require(asset != address(0), "Invalid asset address");
         require(zrc20 != address(0), "Invalid ZRC20 address");
-        require(_tokenAssets[name][chainId] != address(0), "Association does not exist");
+        require(
+            _tokenAssets[name][chainId] != address(0),
+            "Association does not exist"
+        );
 
         _tokenAssets[name][chainId] = asset;
         _tokenZrc20s[name][chainId] = zrc20;
@@ -602,9 +718,15 @@ contract Router is
      * @param name The name of the token
      * @param chainId The chain ID to remove the association for
      */
-    function removeTokenAssociation(string calldata name, uint256 chainId) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function removeTokenAssociation(
+        string calldata name,
+        uint256 chainId
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_supportedTokens[name], "Token does not exist");
-        require(_tokenAssets[name][chainId] != address(0), "Association does not exist");
+        require(
+            _tokenAssets[name][chainId] != address(0),
+            "Association does not exist"
+        );
 
         delete _tokenAssets[name][chainId];
         delete _tokenZrc20s[name][chainId];
@@ -630,16 +752,26 @@ contract Router is
      * @return zrc20Addr The ZRC20 address on ZetaChain
      * @return chainIdValue The chain ID where the asset exists
      */
-    function getTokenAssociation(address zrc20, uint256 chainId)
+    function getTokenAssociation(
+        address zrc20,
+        uint256 chainId
+    )
         public
         view
         returns (address asset, address zrc20Addr, uint256 chainIdValue)
     {
         string memory name = zrc20ToTokenName[zrc20];
         require(_supportedTokens[name], "Token does not exist");
-        require(_tokenAssets[name][chainId] != address(0), "Association does not exist");
+        require(
+            _tokenAssets[name][chainId] != address(0),
+            "Association does not exist"
+        );
 
-        return (_tokenAssets[name][chainId], _tokenZrc20s[name][chainId], chainId);
+        return (
+            _tokenAssets[name][chainId],
+            _tokenZrc20s[name][chainId],
+            chainId
+        );
     }
 
     /**
@@ -649,10 +781,16 @@ contract Router is
      * @return assets Array of asset addresses
      * @return zrc20s Array of ZRC20 addresses
      */
-    function getTokenAssociations(string calldata name)
+    function getTokenAssociations(
+        string calldata name
+    )
         public
         view
-        returns (uint256[] memory chainIds, address[] memory assets, address[] memory zrc20s)
+        returns (
+            uint256[] memory chainIds,
+            address[] memory assets,
+            address[] memory zrc20s
+        )
     {
         require(_supportedTokens[name], "Token does not exist");
 
@@ -690,9 +828,17 @@ contract Router is
      * @dev Updates the withdraw gas limit
      * @param newGasLimit The new gas limit to set
      */
-    function setWithdrawGasLimit(uint256 newGasLimit) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(newGasLimit >= MIN_WITHDRAW_GAS_LIMIT, "Gas limit below minimum");
-        require(newGasLimit <= MAX_WITHDRAW_GAS_LIMIT, "Gas limit above maximum");
+    function setWithdrawGasLimit(
+        uint256 newGasLimit
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(
+            newGasLimit >= MIN_WITHDRAW_GAS_LIMIT,
+            "Gas limit below minimum"
+        );
+        require(
+            newGasLimit <= MAX_WITHDRAW_GAS_LIMIT,
+            "Gas limit above maximum"
+        );
         emit WithdrawGasLimitUpdated(withdrawGasLimit, newGasLimit);
         withdrawGasLimit = newGasLimit;
     }
@@ -702,7 +848,10 @@ contract Router is
      * @param chainId The chain ID to set the gas limit for
      * @param gasLimit The gas limit to set
      */
-    function setChainWithdrawGasLimit(uint256 chainId, uint256 gasLimit) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setChainWithdrawGasLimit(
+        uint256 chainId,
+        uint256 gasLimit
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(gasLimit >= MIN_WITHDRAW_GAS_LIMIT, "Gas limit below minimum");
         require(gasLimit <= MAX_WITHDRAW_GAS_LIMIT, "Gas limit above maximum");
         chainWithdrawGasLimits[chainId] = gasLimit;
@@ -713,7 +862,9 @@ contract Router is
      * @dev Removes a custom gas limit for a specific chain
      * @param chainId The chain ID to remove the gas limit for
      */
-    function removeChainWithdrawGasLimit(uint256 chainId) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function removeChainWithdrawGasLimit(
+        uint256 chainId
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         delete chainWithdrawGasLimits[chainId];
         emit ChainWithdrawGasLimitRemoved(chainId);
     }
@@ -732,7 +883,9 @@ contract Router is
      * @param chainId The chain ID to get the gas limit for
      * @return The gas limit to use for the specified chain
      */
-    function _getChainGasLimit(uint256 chainId) internal view returns (uint256) {
+    function _getChainGasLimit(
+        uint256 chainId
+    ) internal view returns (uint256) {
         // If a chain-specific gas limit is set, use it
         uint256 chainGasLimit = chainWithdrawGasLimits[chainId];
         if (chainGasLimit > 0) {

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -92,26 +92,13 @@ contract Router is
     mapping(uint256 => uint256) public chainWithdrawGasLimits;
 
     // Event emitted when an intent contract is set
-    event IntentContractSet(
-        uint256 indexed chainId,
-        address indexed intentContract
-    );
+    event IntentContractSet(uint256 indexed chainId, address indexed intentContract);
     // Event emitted when a new token is added
     event TokenAdded(string indexed name);
     // Event emitted when a token association is added
-    event TokenAssociationAdded(
-        string indexed name,
-        uint256 indexed chainId,
-        address asset,
-        address zrc20
-    );
+    event TokenAssociationAdded(string indexed name, uint256 indexed chainId, address asset, address zrc20);
     // Event emitted when a token association is updated
-    event TokenAssociationUpdated(
-        string indexed name,
-        uint256 indexed chainId,
-        address asset,
-        address zrc20
-    );
+    event TokenAssociationUpdated(string indexed name, uint256 indexed chainId, address asset, address zrc20);
     // Event emitted when a token association is removed
     event TokenAssociationRemoved(string indexed name, uint256 indexed chainId);
     // Event emitted when an intent settlement is forwarded
@@ -124,15 +111,9 @@ contract Router is
         uint256 tip
     );
     // Event emitted when the gateway is updated
-    event GatewayUpdated(
-        address indexed oldGateway,
-        address indexed newGateway
-    );
+    event GatewayUpdated(address indexed oldGateway, address indexed newGateway);
     // Event emitted when the swap module is updated
-    event SwapModuleUpdated(
-        address indexed oldSwapModule,
-        address indexed newSwapModule
-    );
+    event SwapModuleUpdated(address indexed oldSwapModule, address indexed newSwapModule);
     // Event emitted when the global withdraw gas limit is updated
     event WithdrawGasLimitUpdated(uint256 oldGasLimit, uint256 newGasLimit);
     // Event emitted when a chain-specific withdraw gas limit is set
@@ -150,10 +131,7 @@ contract Router is
      * @param _gateway The address of the gateway contract
      * @param _swapModule The address of the swap module contract
      */
-    function initialize(
-        address _gateway,
-        address _swapModule
-    ) public initializer {
+    function initialize(address _gateway, address _swapModule) public initializer {
         __AccessControl_init();
         __UUPSUpgradeable_init_unchained();
         __Pausable_init_unchained();
@@ -175,9 +153,7 @@ contract Router is
      * @dev Function that authorizes an upgrade, can only be called by an account with the admin role
      * @param newImplementation Address of the new implementation
      */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
     /**
      * @dev Pauses the contract, preventing onCall operations
@@ -198,9 +174,7 @@ contract Router is
      * @dev Updates the gateway address
      * @param _gateway New gateway address
      */
-    function updateGateway(
-        address _gateway
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function updateGateway(address _gateway) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_gateway != address(0), "Gateway cannot be zero address");
         emit GatewayUpdated(gateway, _gateway);
         gateway = _gateway;
@@ -210,13 +184,8 @@ contract Router is
      * @dev Updates the swap module address
      * @param _swapModule New swap module address
      */
-    function updateSwapModule(
-        address _swapModule
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(
-            _swapModule != address(0),
-            "Swap module cannot be zero address"
-        );
+    function updateSwapModule(address _swapModule) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(_swapModule != address(0), "Swap module cannot be zero address");
         emit SwapModuleUpdated(swapModule, _swapModule);
         swapModule = _swapModule;
     }
@@ -228,11 +197,11 @@ contract Router is
      * @param decimalsOut The decimal places of the destination token
      * @return The expected amount with the destination token's decimal precision
      */
-    function calculateExpectedAmount(
-        uint256 amountIn,
-        uint8 decimalsIn,
-        uint8 decimalsOut
-    ) public pure returns (uint256) {
+    function calculateExpectedAmount(uint256 amountIn, uint8 decimalsIn, uint8 decimalsOut)
+        public
+        pure
+        returns (uint256)
+    {
         // Input validation
         require(decimalsIn <= 30, "Source decimals too high");
         require(decimalsOut <= 30, "Destination decimals too high");
@@ -247,11 +216,7 @@ contract Router is
             uint256 scalingFactor = 10 ** (decimalsOut - decimalsIn);
 
             // Check for potential overflow before multiplication
-            require(
-                amountIn == 0 ||
-                    (type(uint256).max / amountIn) >= scalingFactor,
-                "Decimal conversion overflow"
-            );
+            require(amountIn == 0 || (type(uint256).max / amountIn) >= scalingFactor, "Decimal conversion overflow");
 
             return amountIn * scalingFactor;
         }
@@ -266,8 +231,7 @@ contract Router is
     modifier onlyGatewayOrIntent() {
         // Allow calls from gateway or registered intent contracts
         require(
-            msg.sender == gateway ||
-                intentContracts[block.chainid] == msg.sender,
+            msg.sender == gateway || intentContracts[block.chainid] == msg.sender,
             "Only gateway or intent contract can call this function"
         );
         _;
@@ -287,12 +251,10 @@ contract Router is
         bytes calldata payload
     ) external override onlyGatewayOrIntent whenNotPaused {
         // Decode intent payload
-        PayloadUtils.IntentPayload memory intentPayload = PayloadUtils
-            .decodeIntentPayload(payload);
+        PayloadUtils.IntentPayload memory intentPayload = PayloadUtils.decodeIntentPayload(payload);
 
         // Check if target chain is ZetaChain
-        bool isZetaChainDestination = intentPayload.targetChain ==
-            block.chainid;
+        bool isZetaChainDestination = intentPayload.targetChain == block.chainid;
 
         // Create intent information struct
         IntentInformation memory intentInfo = IntentInformation({
@@ -307,9 +269,7 @@ contract Router is
         SettlementInfo memory settlementInfo = _processIntent(intentInfo);
 
         // Convert receiver from bytes to address
-        address receiverAddress = PayloadUtils.bytesToAddress(
-            intentPayload.receiver
-        );
+        address receiverAddress = PayloadUtils.bytesToAddress(intentPayload.receiver);
 
         // Encode settlement payload
         bytes memory settlementPayload = PayloadUtils.encodeSettlementPayload(
@@ -360,34 +320,23 @@ contract Router is
      * @dev Internal function to process the intent, convert amounts, and returns the settlement info
      * @param intentInfo The struct containing all intent processing information
      */
-    function _processIntent(
-        IntentInformation memory intentInfo
-    ) internal returns (SettlementInfo memory settlementInfo) {
+    function _processIntent(IntentInformation memory intentInfo)
+        internal
+        returns (SettlementInfo memory settlementInfo)
+    {
         // Verify the call is coming from a registered intent contract
         require(
-            intentContracts[intentInfo.context.chainID] ==
-                intentInfo.context.senderEVM,
+            intentContracts[intentInfo.context.chainID] == intentInfo.context.senderEVM,
             "Call must be from intent contract"
         );
 
         // Get token association for target chain
-        (
-            settlementInfo.targetAsset,
-            settlementInfo.targetZRC20,
-
-        ) = getTokenAssociation(
-            intentInfo.zrc20,
-            intentInfo.intentPayload.targetChain
-        );
+        (settlementInfo.targetAsset, settlementInfo.targetZRC20,) =
+            getTokenAssociation(intentInfo.zrc20, intentInfo.intentPayload.targetChain);
 
         // Get intent contract on target chain
-        settlementInfo.intentContract = intentContracts[
-            intentInfo.intentPayload.targetChain
-        ];
-        require(
-            settlementInfo.intentContract != address(0),
-            "Intent contract not set for target chain"
-        );
+        settlementInfo.intentContract = intentContracts[intentInfo.intentPayload.targetChain];
+        require(settlementInfo.intentContract != address(0), "Intent contract not set for target chain");
 
         // Get decimals for source and target tokens
         uint8 sourceDecimals = IZRC20(intentInfo.zrc20).decimals();
@@ -396,24 +345,15 @@ contract Router is
         // Convert amounts to target token decimal representation
         uint256 wantedAmountWithTip;
         uint256 wantedTip;
-        (
-            settlementInfo.wantedAmount,
-            wantedTip,
-            wantedAmountWithTip
-        ) = _convertAmountsForDecimals(
-            intentInfo.intentPayload.amount,
-            intentInfo.amountWithTip,
-            sourceDecimals,
-            targetDecimals
+        (settlementInfo.wantedAmount, wantedTip, wantedAmountWithTip) = _convertAmountsForDecimals(
+            intentInfo.intentPayload.amount, intentInfo.amountWithTip, sourceDecimals, targetDecimals
         );
 
         // Get the appropriate gas limit for the target chain - use custom gas limit if provided, otherwise fallback to default
         if (intentInfo.intentPayload.gasLimit > 0) {
             settlementInfo.gasLimit = intentInfo.intentPayload.gasLimit;
         } else {
-            settlementInfo.gasLimit = _getChainGasLimit(
-                intentInfo.intentPayload.targetChain
-            );
+            settlementInfo.gasLimit = _getChainGasLimit(intentInfo.intentPayload.targetChain);
         }
 
         // Initialize gas fee variables
@@ -423,9 +363,8 @@ contract Router is
         // Only get gas fee if the destination is not ZetaChain
         if (!intentInfo.isZetaChainDestination) {
             // Get gas fee info from target ZRC20
-            (settlementInfo.gasZRC20, settlementInfo.gasFee) = IZRC20(
-                settlementInfo.targetZRC20
-            ).withdrawGasFeeWithGasLimit(settlementInfo.gasLimit);
+            (settlementInfo.gasZRC20, settlementInfo.gasFee) =
+                IZRC20(settlementInfo.targetZRC20).withdrawGasFeeWithGasLimit(settlementInfo.gasLimit);
         }
 
         settlementInfo.actualAmount = settlementInfo.wantedAmount;
@@ -438,10 +377,7 @@ contract Router is
         } else {
             // Approve swap module to spend tokens
             IERC20(intentInfo.zrc20).approve(swapModule, 0);
-            IERC20(intentInfo.zrc20).approve(
-                swapModule,
-                intentInfo.amountWithTip
-            );
+            IERC20(intentInfo.zrc20).approve(swapModule, intentInfo.amountWithTip);
 
             // Perform swap through swap module
             settlementInfo.amountWithTipOut = ISwap(swapModule).swap(
@@ -457,8 +393,7 @@ contract Router is
             // If swap returns more than expected (surplus), slippageAndFeeCost will be 0
             // Note: Surplus amounts are currently ignored as they are too small to handle
             // This will be addressed in future updates
-            uint256 slippageAndFeeCost = wantedAmountWithTip >
-                settlementInfo.amountWithTipOut
+            uint256 slippageAndFeeCost = wantedAmountWithTip > settlementInfo.amountWithTipOut
                 ? wantedAmountWithTip - settlementInfo.amountWithTipOut
                 : 0;
 
@@ -472,14 +407,9 @@ contract Router is
                 // Calculate how much remaining slippage to cover from the amount
                 uint256 remainingCost = slippageAndFeeCost - wantedTip;
                 // Ensure the amount is greater than the remaining cost, otherwise fail
-                require(
-                    settlementInfo.wantedAmount > remainingCost,
-                    "Amount insufficient to cover costs after tip"
-                );
+                require(settlementInfo.wantedAmount > remainingCost, "Amount insufficient to cover costs after tip");
                 // Reduce the actual amount by the remaining cost
-                settlementInfo.actualAmount =
-                    settlementInfo.wantedAmount -
-                    remainingCost;
+                settlementInfo.actualAmount = settlementInfo.wantedAmount - remainingCost;
             }
         }
 
@@ -504,9 +434,7 @@ contract Router is
         IERC20(zrc20).approve(intentContract, amount);
 
         // Create a MessageContext
-        IIntent.MessageContext memory intentContext = IIntent.MessageContext({
-            sender: address(this)
-        });
+        IIntent.MessageContext memory intentContext = IIntent.MessageContext({sender: address(this)});
 
         // Call the intent contract directly
         IIntent(intentContract).onCall(intentContext, settlementPayload);
@@ -534,10 +462,7 @@ contract Router is
         uint256 gasLimit
     ) internal {
         // Prepare call options with provided gas limit
-        IGateway.CallOptions memory callOptions = IGateway.CallOptions({
-            gasLimit: gasLimit,
-            isArbitraryCall: false
-        });
+        IGateway.CallOptions memory callOptions = IGateway.CallOptions({gasLimit: gasLimit, isArbitraryCall: false});
 
         // Prepare revert options
         IGateway.RevertOptions memory revertOptions = IGateway.RevertOptions({
@@ -556,12 +481,7 @@ contract Router is
 
         // Call gateway to withdraw and call intent contract
         IGateway(gateway).withdrawAndCall(
-            abi.encodePacked(intentContract),
-            amount,
-            targetZRC20,
-            settlementPayload,
-            callOptions,
-            revertOptions
+            abi.encodePacked(intentContract), amount, targetZRC20, settlementPayload, callOptions, revertOptions
         );
     }
 
@@ -580,26 +500,10 @@ contract Router is
         uint256 amountWithTip,
         uint8 sourceDecimals,
         uint8 targetDecimals
-    )
-        private
-        pure
-        returns (
-            uint256 wantedAmount,
-            uint256 wantedTip,
-            uint256 wantedAmountWithTip
-        )
-    {
+    ) private pure returns (uint256 wantedAmount, uint256 wantedTip, uint256 wantedAmountWithTip) {
         // Convert the individual amount and the total amount with tip
-        wantedAmount = calculateExpectedAmount(
-            amount,
-            sourceDecimals,
-            targetDecimals
-        );
-        wantedAmountWithTip = calculateExpectedAmount(
-            amountWithTip,
-            sourceDecimals,
-            targetDecimals
-        );
+        wantedAmount = calculateExpectedAmount(amount, sourceDecimals, targetDecimals);
+        wantedAmountWithTip = calculateExpectedAmount(amountWithTip, sourceDecimals, targetDecimals);
 
         // Calculate tip as the difference to maintain the invariant:
         // wantedAmount + wantedTip == wantedAmountWithTip
@@ -620,14 +524,8 @@ contract Router is
      * @param chainId The chain ID to set the intent contract for
      * @param intentContract The address of the intent contract
      */
-    function setIntentContract(
-        uint256 chainId,
-        address intentContract
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(
-            intentContract != address(0),
-            "Invalid intent contract address"
-        );
+    function setIntentContract(uint256 chainId, address intentContract) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(intentContract != address(0), "Invalid intent contract address");
         intentContracts[chainId] = intentContract;
         emit IntentContractSet(chainId, intentContract);
     }
@@ -645,9 +543,7 @@ contract Router is
      * @dev Adds a new supported token
      * @param name The name of the token (e.g., "USDC")
      */
-    function addToken(
-        string calldata name
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function addToken(string calldata name) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(bytes(name).length > 0, "Token name cannot be empty");
         require(!_supportedTokens[name], "Token already exists");
 
@@ -663,19 +559,14 @@ contract Router is
      * @param asset The ERC20 address on the source chain
      * @param zrc20 The ZRC20 address on ZetaChain
      */
-    function addTokenAssociation(
-        string calldata name,
-        uint256 chainId,
-        address asset,
-        address zrc20
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function addTokenAssociation(string calldata name, uint256 chainId, address asset, address zrc20)
+        public
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
         require(_supportedTokens[name], "Token does not exist");
         require(asset != address(0), "Invalid asset address");
         require(zrc20 != address(0), "Invalid ZRC20 address");
-        require(
-            _tokenAssets[name][chainId] == address(0),
-            "Association already exists"
-        );
+        require(_tokenAssets[name][chainId] == address(0), "Association already exists");
 
         _tokenAssets[name][chainId] = asset;
         _tokenZrc20s[name][chainId] = zrc20;
@@ -692,19 +583,14 @@ contract Router is
      * @param asset The new ERC20 address on the source chain
      * @param zrc20 The new ZRC20 address on ZetaChain
      */
-    function updateTokenAssociation(
-        string calldata name,
-        uint256 chainId,
-        address asset,
-        address zrc20
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function updateTokenAssociation(string calldata name, uint256 chainId, address asset, address zrc20)
+        public
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
         require(_supportedTokens[name], "Token does not exist");
         require(asset != address(0), "Invalid asset address");
         require(zrc20 != address(0), "Invalid ZRC20 address");
-        require(
-            _tokenAssets[name][chainId] != address(0),
-            "Association does not exist"
-        );
+        require(_tokenAssets[name][chainId] != address(0), "Association does not exist");
 
         _tokenAssets[name][chainId] = asset;
         _tokenZrc20s[name][chainId] = zrc20;
@@ -718,15 +604,9 @@ contract Router is
      * @param name The name of the token
      * @param chainId The chain ID to remove the association for
      */
-    function removeTokenAssociation(
-        string calldata name,
-        uint256 chainId
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function removeTokenAssociation(string calldata name, uint256 chainId) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_supportedTokens[name], "Token does not exist");
-        require(
-            _tokenAssets[name][chainId] != address(0),
-            "Association does not exist"
-        );
+        require(_tokenAssets[name][chainId] != address(0), "Association does not exist");
 
         delete _tokenAssets[name][chainId];
         delete _tokenZrc20s[name][chainId];
@@ -752,26 +632,16 @@ contract Router is
      * @return zrc20Addr The ZRC20 address on ZetaChain
      * @return chainIdValue The chain ID where the asset exists
      */
-    function getTokenAssociation(
-        address zrc20,
-        uint256 chainId
-    )
+    function getTokenAssociation(address zrc20, uint256 chainId)
         public
         view
         returns (address asset, address zrc20Addr, uint256 chainIdValue)
     {
         string memory name = zrc20ToTokenName[zrc20];
         require(_supportedTokens[name], "Token does not exist");
-        require(
-            _tokenAssets[name][chainId] != address(0),
-            "Association does not exist"
-        );
+        require(_tokenAssets[name][chainId] != address(0), "Association does not exist");
 
-        return (
-            _tokenAssets[name][chainId],
-            _tokenZrc20s[name][chainId],
-            chainId
-        );
+        return (_tokenAssets[name][chainId], _tokenZrc20s[name][chainId], chainId);
     }
 
     /**
@@ -781,16 +651,10 @@ contract Router is
      * @return assets Array of asset addresses
      * @return zrc20s Array of ZRC20 addresses
      */
-    function getTokenAssociations(
-        string calldata name
-    )
+    function getTokenAssociations(string calldata name)
         public
         view
-        returns (
-            uint256[] memory chainIds,
-            address[] memory assets,
-            address[] memory zrc20s
-        )
+        returns (uint256[] memory chainIds, address[] memory assets, address[] memory zrc20s)
     {
         require(_supportedTokens[name], "Token does not exist");
 
@@ -828,17 +692,9 @@ contract Router is
      * @dev Updates the withdraw gas limit
      * @param newGasLimit The new gas limit to set
      */
-    function setWithdrawGasLimit(
-        uint256 newGasLimit
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(
-            newGasLimit >= MIN_WITHDRAW_GAS_LIMIT,
-            "Gas limit below minimum"
-        );
-        require(
-            newGasLimit <= MAX_WITHDRAW_GAS_LIMIT,
-            "Gas limit above maximum"
-        );
+    function setWithdrawGasLimit(uint256 newGasLimit) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(newGasLimit >= MIN_WITHDRAW_GAS_LIMIT, "Gas limit below minimum");
+        require(newGasLimit <= MAX_WITHDRAW_GAS_LIMIT, "Gas limit above maximum");
         emit WithdrawGasLimitUpdated(withdrawGasLimit, newGasLimit);
         withdrawGasLimit = newGasLimit;
     }
@@ -848,10 +704,7 @@ contract Router is
      * @param chainId The chain ID to set the gas limit for
      * @param gasLimit The gas limit to set
      */
-    function setChainWithdrawGasLimit(
-        uint256 chainId,
-        uint256 gasLimit
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setChainWithdrawGasLimit(uint256 chainId, uint256 gasLimit) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(gasLimit >= MIN_WITHDRAW_GAS_LIMIT, "Gas limit below minimum");
         require(gasLimit <= MAX_WITHDRAW_GAS_LIMIT, "Gas limit above maximum");
         chainWithdrawGasLimits[chainId] = gasLimit;
@@ -862,9 +715,7 @@ contract Router is
      * @dev Removes a custom gas limit for a specific chain
      * @param chainId The chain ID to remove the gas limit for
      */
-    function removeChainWithdrawGasLimit(
-        uint256 chainId
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function removeChainWithdrawGasLimit(uint256 chainId) public onlyRole(DEFAULT_ADMIN_ROLE) {
         delete chainWithdrawGasLimits[chainId];
         emit ChainWithdrawGasLimitRemoved(chainId);
     }
@@ -883,9 +734,7 @@ contract Router is
      * @param chainId The chain ID to get the gas limit for
      * @return The gas limit to use for the specified chain
      */
-    function _getChainGasLimit(
-        uint256 chainId
-    ) internal view returns (uint256) {
+    function _getChainGasLimit(uint256 chainId) internal view returns (uint256) {
         // If a chain-specific gas limit is set, use it
         uint256 chainGasLimit = chainWithdrawGasLimits[chainId];
         if (chainGasLimit > 0) {

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -30,10 +30,23 @@ contract RouterTest is Test {
     address public user1;
     address public user2;
 
-    event IntentContractSet(uint256 indexed chainId, address indexed intentContract);
+    event IntentContractSet(
+        uint256 indexed chainId,
+        address indexed intentContract
+    );
     event TokenAdded(string indexed name);
-    event TokenAssociationAdded(string indexed name, uint256 indexed chainId, address asset, address zrc20);
-    event TokenAssociationUpdated(string indexed name, uint256 indexed chainId, address asset, address zrc20);
+    event TokenAssociationAdded(
+        string indexed name,
+        uint256 indexed chainId,
+        address asset,
+        address zrc20
+    );
+    event TokenAssociationUpdated(
+        string indexed name,
+        uint256 indexed chainId,
+        address asset,
+        address zrc20
+    );
     event TokenAssociationRemoved(string indexed name, uint256 indexed chainId);
     event IntentSettlementForwarded(
         bytes indexed sender,
@@ -51,15 +64,25 @@ contract RouterTest is Test {
     event ChainWithdrawGasLimitRemoved(uint256 indexed chainId);
 
     // Helper function to create a properly initialized Router
-    function createInitializedRouter(address gatewayAddr, address swapModuleAddr) internal returns (Router) {
+    function createInitializedRouter(
+        address gatewayAddr,
+        address swapModuleAddr
+    ) internal returns (Router) {
         // Deploy implementation
         Router implementation = new Router();
 
         // Prepare initialization data
-        bytes memory initData = abi.encodeWithSelector(Router.initialize.selector, gatewayAddr, swapModuleAddr);
+        bytes memory initData = abi.encodeWithSelector(
+            Router.initialize.selector,
+            gatewayAddr,
+            swapModuleAddr
+        );
 
         // Deploy proxy
-        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), initData);
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(implementation),
+            initData
+        );
 
         return Router(address(proxy));
     }
@@ -83,7 +106,11 @@ contract RouterTest is Test {
 
     // Helper function to create a router with the fixed output swap module
     function createFixedOutputRouter() internal returns (Router) {
-        return createInitializedRouter(address(gateway), address(fixedOutputSwapModule));
+        return
+            createInitializedRouter(
+                address(gateway),
+                address(fixedOutputSwapModule)
+            );
     }
 
     // Helper function for access control error expectations
@@ -91,7 +118,13 @@ contract RouterTest is Test {
         bytes32 role = 0x00; // DEFAULT_ADMIN_ROLE
         vm.expectRevert(
             abi.encodeWithSelector(
-                bytes4(keccak256("AccessControlUnauthorizedAccount(address,bytes32)")), account, role
+                bytes4(
+                    keccak256(
+                        "AccessControlUnauthorizedAccount(address,bytes32)"
+                    )
+                ),
+                account,
+                role
             )
         );
     }
@@ -191,8 +224,11 @@ contract RouterTest is Test {
         emit TokenAssociationAdded(name, chainId, asset, zrc20);
         router.addTokenAssociation(name, chainId, asset, zrc20);
 
-        (address returnedAsset, address returnedZrc20, uint256 chainIdValue) =
-            router.getTokenAssociation(zrc20, chainId);
+        (
+            address returnedAsset,
+            address returnedZrc20,
+            uint256 chainIdValue
+        ) = router.getTokenAssociation(zrc20, chainId);
         assertEq(returnedAsset, asset);
         assertEq(returnedZrc20, zrc20);
         assertEq(chainIdValue, chainId);
@@ -259,14 +295,19 @@ contract RouterTest is Test {
         emit TokenAssociationUpdated(name, chainId, asset2, zrc20);
         router.updateTokenAssociation(name, chainId, asset2, zrc20);
 
-        (address returnedAsset, address returnedZrc20, uint256 chainIdValue) =
-            router.getTokenAssociation(zrc20, chainId);
+        (
+            address returnedAsset,
+            address returnedZrc20,
+            uint256 chainIdValue
+        ) = router.getTokenAssociation(zrc20, chainId);
         assertEq(returnedAsset, asset2);
         assertEq(returnedZrc20, zrc20);
         assertEq(chainIdValue, chainId);
     }
 
-    function test_UpdateTokenAssociation_NonExistentAssociationReverts() public {
+    function test_UpdateTokenAssociation_NonExistentAssociationReverts()
+        public
+    {
         string memory name = "USDC";
         uint256 chainId = 1;
         address asset = makeAddr("asset");
@@ -308,7 +349,9 @@ contract RouterTest is Test {
         router.getTokenAssociation(zrc20, chainId);
     }
 
-    function test_RemoveTokenAssociation_NonExistentAssociationReverts() public {
+    function test_RemoveTokenAssociation_NonExistentAssociationReverts()
+        public
+    {
         string memory name = "USDC";
         uint256 chainId = 1;
 
@@ -343,8 +386,11 @@ contract RouterTest is Test {
         router.addTokenAssociation(name, chainId1, asset1, zrc20);
         router.addTokenAssociation(name, chainId2, asset2, zrc20);
 
-        (uint256[] memory chainIds, address[] memory assets, address[] memory zrc20s) =
-            router.getTokenAssociations(name);
+        (
+            uint256[] memory chainIds,
+            address[] memory assets,
+            address[] memory zrc20s
+        ) = router.getTokenAssociations(name);
         assertEq(chainIds.length, 2);
         assertEq(chainIds[0], chainId1);
         assertEq(chainIds[1], chainId2);
@@ -381,8 +427,18 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
-        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
+        router.addTokenAssociation(
+            tokenName,
+            sourceChainId,
+            inputAsset,
+            address(inputToken)
+        );
+        router.addTokenAssociation(
+            tokenName,
+            targetChainId,
+            targetAsset,
+            address(targetZRC20)
+        );
 
         // Setup intent payload
         bytes32 intentId = keccak256("test-intent");
@@ -390,8 +446,16 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes =
-            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
+        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
+            intentId,
+            amount,
+            tip,
+            targetChainId,
+            receiver,
+            false,
+            "",
+            0
+        );
 
         // Set modest slippage (5%)
         swapModule.setSlippage(500);
@@ -400,7 +464,10 @@ contract RouterTest is Test {
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                router.withdrawGasLimit()
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -412,15 +479,21 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
+        router.onCall(
+            context,
+            address(inputToken),
+            amount + tip,
+            intentPayloadBytes
+        );
 
         // Verify approvals were made to the gateway
         assertTrue(
@@ -428,7 +501,8 @@ contract RouterTest is Test {
             "Router should approve target ZRC20 to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(router), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(router), address(gateway)) > 0,
+            "Router should approve gas ZRC20 to gateway"
         );
     }
 
@@ -446,8 +520,18 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
-        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
+        router.addTokenAssociation(
+            tokenName,
+            sourceChainId,
+            inputAsset,
+            address(inputToken)
+        );
+        router.addTokenAssociation(
+            tokenName,
+            targetChainId,
+            targetAsset,
+            address(targetZRC20)
+        );
 
         // Setup intent payload with a very small amount and tip
         bytes32 intentId = keccak256("test-intent");
@@ -474,7 +558,10 @@ contract RouterTest is Test {
         uint256 gasFee = 11 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                router.withdrawGasLimit()
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -484,11 +571,12 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
 
         // Call onCall and expect it to revert due to insufficient amount
         // - We're passing in 100 ether but the slippage will be 10 ether (10%)
@@ -567,8 +655,18 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
-        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
+        router.addTokenAssociation(
+            tokenName,
+            sourceChainId,
+            inputAsset,
+            address(inputToken)
+        );
+        router.addTokenAssociation(
+            tokenName,
+            targetChainId,
+            targetAsset,
+            address(targetZRC20)
+        );
 
         // Setup intent payload with amount and small tip
         bytes32 intentId = keccak256("test-intent");
@@ -576,8 +674,16 @@ contract RouterTest is Test {
         uint256 tip = 3 ether; // Small tip that won't cover all costs
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes =
-            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
+        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
+            intentId,
+            amount,
+            tip,
+            targetChainId,
+            receiver,
+            false,
+            "",
+            0
+        );
 
         // Set high slippage (8%) so we can observe amount reduction
         swapModule.setSlippage(800); // 8% slippage = 8 ether on 100 ether
@@ -586,7 +692,10 @@ contract RouterTest is Test {
         uint256 gasFee = 2 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                router.withdrawGasLimit()
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -602,11 +711,12 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
 
         // Check that we correctly set the event expectations BEFORE the call
         // Event expectations must be set before the call that emits them
@@ -622,7 +732,12 @@ contract RouterTest is Test {
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
+        router.onCall(
+            context,
+            address(inputToken),
+            amount + tip,
+            intentPayloadBytes
+        );
 
         // Verify approvals to the gateway
         assertTrue(
@@ -630,7 +745,8 @@ contract RouterTest is Test {
             "Router should approve target ZRC20 to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(router), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(router), address(gateway)) > 0,
+            "Router should approve gas ZRC20 to gateway"
         );
 
         // At this point we've confirmed:
@@ -657,8 +773,18 @@ contract RouterTest is Test {
         fixedRouter.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        fixedRouter.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
-        fixedRouter.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
+        fixedRouter.addTokenAssociation(
+            tokenName,
+            sourceChainId,
+            inputAsset,
+            address(inputToken)
+        );
+        fixedRouter.addTokenAssociation(
+            tokenName,
+            targetChainId,
+            targetAsset,
+            address(targetZRC20)
+        );
 
         // Setup intent payload
         bytes32 intentId = keccak256("test-intent");
@@ -666,19 +792,36 @@ contract RouterTest is Test {
         uint256 tip = 10 * 10 ** 6; // 10 USDC with 6 decimals
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes =
-            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
+        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
+            intentId,
+            amount,
+            tip,
+            targetChainId,
+            receiver,
+            false,
+            "",
+            0
+        );
 
         // Mock decimals for input token (6 decimals like USDC)
-        vm.mockCall(address(inputToken), abi.encodeWithSelector(IZRC20.decimals.selector), abi.encode(uint8(6)));
+        vm.mockCall(
+            address(inputToken),
+            abi.encodeWithSelector(IZRC20.decimals.selector),
+            abi.encode(uint8(6))
+        );
 
         // Mock decimals for target token (18 decimals like most tokens)
-        vm.mockCall(address(targetZRC20), abi.encodeWithSelector(IZRC20.decimals.selector), abi.encode(uint8(18)));
+        vm.mockCall(
+            address(targetZRC20),
+            abi.encodeWithSelector(IZRC20.decimals.selector),
+            abi.encode(uint8(18))
+        );
 
         // Calculate the expected amount in target decimals
         uint256 expectedAmountInTargetDecimals = amount * 10 ** 12; // 100e6 * 10^12 = 100e18
         uint256 expectedTipInTargetDecimals = tip * 10 ** 12; // 10e6 * 10^12 = 10e18
-        uint256 expectedTotal = expectedAmountInTargetDecimals + expectedTipInTargetDecimals;
+        uint256 expectedTotal = expectedAmountInTargetDecimals +
+            expectedTipInTargetDecimals;
 
         // Set a fixed output amount that's slightly less than the converted total
         // This simulates some slippage
@@ -688,7 +831,10 @@ contract RouterTest is Test {
         uint256 gasFee = 1 ether; // 1 token with 18 decimals for gas fee
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, fixedRouter.withdrawGasLimit()),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                fixedRouter.withdrawGasLimit()
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -698,11 +844,12 @@ contract RouterTest is Test {
         gasZRC20.mint(address(fixedOutputSwapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
 
         // Check event is emitted with correct values - tip should be slightly reduced due to slippage
         vm.expectEmit();
@@ -717,7 +864,12 @@ contract RouterTest is Test {
 
         // Call onCall
         vm.prank(address(gateway));
-        fixedRouter.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
+        fixedRouter.onCall(
+            context,
+            address(inputToken),
+            amount + tip,
+            intentPayloadBytes
+        );
 
         // Verify approvals were made to the gateway
         assertTrue(
@@ -725,7 +877,8 @@ contract RouterTest is Test {
             "Router should approve target ZRC20 to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(fixedRouter), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(fixedRouter), address(gateway)) > 0,
+            "Router should approve gas ZRC20 to gateway"
         );
     }
 
@@ -770,20 +923,35 @@ contract RouterTest is Test {
         assertFalse(router.paused(), "Router should not be paused initially");
 
         // Test that someone with PAUSER_ROLE can pause
-        assertTrue(router.hasRole(router.PAUSER_ROLE(), address(this)), "Test contract should have PAUSER_ROLE");
+        assertTrue(
+            router.hasRole(router.PAUSER_ROLE(), address(this)),
+            "Test contract should have PAUSER_ROLE"
+        );
         router.pause();
-        assertTrue(router.paused(), "Router should be paused after calling pause()");
+        assertTrue(
+            router.paused(),
+            "Router should be paused after calling pause()"
+        );
 
         // Test that someone with DEFAULT_ADMIN_ROLE can unpause
-        assertTrue(router.hasRole(0x00, address(this)), "Test contract should have DEFAULT_ADMIN_ROLE");
+        assertTrue(
+            router.hasRole(0x00, address(this)),
+            "Test contract should have DEFAULT_ADMIN_ROLE"
+        );
         router.unpause();
-        assertFalse(router.paused(), "Router should not be paused after calling unpause()");
+        assertFalse(
+            router.paused(),
+            "Router should not be paused after calling unpause()"
+        );
     }
 
     function test_RevertWhen_NonPauserTriesToPause() public {
         // Make sure user1 doesn't have PAUSER_ROLE
         bytes32 pauserRole = router.PAUSER_ROLE();
-        assertFalse(router.hasRole(pauserRole, user1), "User1 should not have PAUSER_ROLE");
+        assertFalse(
+            router.hasRole(pauserRole, user1),
+            "User1 should not have PAUSER_ROLE"
+        );
 
         // Set up the prank
         vm.prank(user1);
@@ -800,7 +968,10 @@ contract RouterTest is Test {
         }
 
         // Verify that the call reverted
-        assertTrue(hasReverted, "Call to pause() should revert when called by non-pauser");
+        assertTrue(
+            hasReverted,
+            "Call to pause() should revert when called by non-pauser"
+        );
 
         // Verify that the router is still not paused
         assertFalse(router.paused(), "Router should not be paused");
@@ -813,7 +984,10 @@ contract RouterTest is Test {
 
         // Make sure user1 doesn't have DEFAULT_ADMIN_ROLE
         bytes32 adminRole = 0x00; // DEFAULT_ADMIN_ROLE
-        assertFalse(router.hasRole(adminRole, user1), "User1 should not have DEFAULT_ADMIN_ROLE");
+        assertFalse(
+            router.hasRole(adminRole, user1),
+            "User1 should not have DEFAULT_ADMIN_ROLE"
+        );
 
         // Set up the prank
         vm.prank(user1);
@@ -830,7 +1004,10 @@ contract RouterTest is Test {
         }
 
         // Verify that the call reverted
-        assertTrue(hasReverted, "Call to unpause() should revert when called by non-admin");
+        assertTrue(
+            hasReverted,
+            "Call to unpause() should revert when called by non-admin"
+        );
 
         // Verify that the router is still paused
         assertTrue(router.paused(), "Router should still be paused");
@@ -843,11 +1020,12 @@ contract RouterTest is Test {
         router.setIntentContract(sourceChainId, sourceIntentContract);
 
         // Setup context and a dummy payload
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
         bytes memory dummyPayload = new bytes(0);
 
         // Pause the router
@@ -869,7 +1047,10 @@ contract RouterTest is Test {
         }
 
         // Verify that the call reverted
-        assertTrue(hasReverted, "Call to onCall() should revert when router is paused");
+        assertTrue(
+            hasReverted,
+            "Call to onCall() should revert when router is paused"
+        );
     }
 
     function test_RouterUpgrade() public {
@@ -888,14 +1069,30 @@ contract RouterTest is Test {
         router.upgradeToAndCall(address(newImplementation), "");
 
         // Verify that storage was preserved after upgrade
-        assertEq(router.gateway(), originalGateway, "Gateway address should be preserved after upgrade");
-        assertEq(router.swapModule(), originalSwapModule, "Swap module address should be preserved after upgrade");
-        assertEq(router.withdrawGasLimit(), originalGasLimit, "Withdraw gas limit should be preserved after upgrade");
+        assertEq(
+            router.gateway(),
+            originalGateway,
+            "Gateway address should be preserved after upgrade"
+        );
+        assertEq(
+            router.swapModule(),
+            originalSwapModule,
+            "Swap module address should be preserved after upgrade"
+        );
+        assertEq(
+            router.withdrawGasLimit(),
+            originalGasLimit,
+            "Withdraw gas limit should be preserved after upgrade"
+        );
 
         // Verify that we can still call functions on the upgraded router
         uint256 newGasLimit = originalGasLimit + 100000;
         router.setWithdrawGasLimit(newGasLimit);
-        assertEq(router.withdrawGasLimit(), newGasLimit, "Should be able to set new values after upgrade");
+        assertEq(
+            router.withdrawGasLimit(),
+            newGasLimit,
+            "Should be able to set new values after upgrade"
+        );
     }
 
     function test_RouterUpgrade_OnlyAdminCanUpgrade() public {
@@ -914,7 +1111,10 @@ contract RouterTest is Test {
         uint256 targetChainId = 2;
         address zetaChainIntentContract = makeAddr("zetaChainIntentContract");
         router.setIntentContract(zetaChainId, zetaChainIntentContract);
-        router.setIntentContract(targetChainId, makeAddr("targetIntentContract"));
+        router.setIntentContract(
+            targetChainId,
+            makeAddr("targetIntentContract")
+        );
 
         // Setup token associations for both source and target chains
         string memory tokenName = "USDC";
@@ -922,25 +1122,46 @@ contract RouterTest is Test {
 
         // Add token association for the source chain (ZetaChain)
         address sourceAsset = address(inputToken); // Use inputToken as the source asset
-        router.addTokenAssociation(tokenName, zetaChainId, sourceAsset, address(inputToken));
+        router.addTokenAssociation(
+            tokenName,
+            zetaChainId,
+            sourceAsset,
+            address(inputToken)
+        );
 
         // Add token association for the target chain
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
+        router.addTokenAssociation(
+            tokenName,
+            targetChainId,
+            targetAsset,
+            address(targetZRC20)
+        );
 
         // Create intent payload
         bytes32 intentId = keccak256("zetachain-intent-test");
         uint256 amount = 100 ether;
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
-        bytes memory intentPayloadBytes =
-            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
+        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
+            intentId,
+            amount,
+            tip,
+            targetChainId,
+            receiver,
+            false,
+            "",
+            0
+        );
 
         // Mock setup for withdrawGasFeeWithGasLimit
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                router.withdrawGasLimit()
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -952,18 +1173,24 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context to simulate call from ZetaChain Intent
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: zetaChainId,
-            sender: abi.encodePacked(zetaChainIntentContract),
-            senderEVM: zetaChainIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: zetaChainId,
+                sender: abi.encodePacked(zetaChainIntentContract),
+                senderEVM: zetaChainIntentContract
+            });
 
         // Start recording logs to verify events
         vm.recordLogs();
 
         // Call onCall as if from the Intent contract on ZetaChain
         vm.prank(address(gateway));
-        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
+        router.onCall(
+            context,
+            address(inputToken),
+            amount + tip,
+            intentPayloadBytes
+        );
 
         // Verify approval to gateway was made
         assertTrue(
@@ -971,7 +1198,8 @@ contract RouterTest is Test {
             "Router should approve target ZRC20 to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(router), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(router), address(gateway)) > 0,
+            "Router should approve gas ZRC20 to gateway"
         );
 
         // Verify IntentSettlementForwarded event was emitted with correct parameters
@@ -980,17 +1208,27 @@ contract RouterTest is Test {
 
         for (uint256 i = 0; i < entries.length; i++) {
             // The event signature for IntentSettlementForwarded
-            bytes32 eventSig = keccak256("IntentSettlementForwarded(bytes,uint256,uint256,address,uint256,uint256)");
+            bytes32 eventSig = keccak256(
+                "IntentSettlementForwarded(bytes,uint256,uint256,address,uint256,uint256)"
+            );
             if (entries[i].topics[0] == eventSig) {
                 foundEvent = true;
 
                 // Decode the non-indexed parameters
-                (address zrc20, uint256 eventAmount, uint256 eventTip) =
-                    abi.decode(entries[i].data, (address, uint256, uint256));
+                (address zrc20, uint256 eventAmount, uint256 eventTip) = abi
+                    .decode(entries[i].data, (address, uint256, uint256));
 
                 // Verify the event parameters
-                assertEq(zrc20, address(inputToken), "ZRC20 address in event doesn't match");
-                assertEq(eventAmount, amount + tip, "Amount in event doesn't match"); // The event reports the total amount including tip
+                assertEq(
+                    zrc20,
+                    address(inputToken),
+                    "ZRC20 address in event doesn't match"
+                );
+                assertEq(
+                    eventAmount,
+                    amount + tip,
+                    "Amount in event doesn't match"
+                ); // The event reports the total amount including tip
                 assertEq(eventTip, 9 ether, "Tip in event doesn't match"); // Actual tip in the event is 9 ether (1 ether is used for gas)
             }
         }
@@ -1018,8 +1256,18 @@ contract RouterTest is Test {
         address targetAsset = makeAddr("target_asset");
 
         // Add token associations for source chain and ZetaChain
-        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
-        router.addTokenAssociation(tokenName, zetaChainId, targetAsset, address(targetZRC20));
+        router.addTokenAssociation(
+            tokenName,
+            sourceChainId,
+            inputAsset,
+            address(inputToken)
+        );
+        router.addTokenAssociation(
+            tokenName,
+            zetaChainId,
+            targetAsset,
+            address(targetZRC20)
+        );
 
         // Setup intent payload with ZetaChain as the target
         bytes32 intentId = keccak256("zetachain-target-test");
@@ -1027,8 +1275,16 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes =
-            PayloadUtils.encodeIntentPayload(intentId, amount, tip, zetaChainId, receiver, false, "", 0);
+        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
+            intentId,
+            amount,
+            tip,
+            zetaChainId,
+            receiver,
+            false,
+            "",
+            0
+        );
 
         // Set modest slippage (5%)
         swapModule.setSlippage(500);
@@ -1038,7 +1294,10 @@ contract RouterTest is Test {
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                router.withdrawGasLimit()
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1053,35 +1312,51 @@ contract RouterTest is Test {
         gasZRC20.mint(address(router), gasFee);
 
         // Setup context for the source chain
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
 
         // Start recording logs to verify events
         vm.recordLogs();
 
         // Call onCall - this should directly call the Intent contract instead of using the gateway
         vm.prank(address(gateway));
-        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
+        router.onCall(
+            context,
+            address(inputToken),
+            amount + tip,
+            intentPayloadBytes
+        );
 
         // Verify IntentSettlementForwarded event was emitted
         Vm.Log[] memory entries = vm.getRecordedLogs();
         bool foundEvent = false;
 
         for (uint256 i = 0; i < entries.length; i++) {
-            bytes32 eventSig = keccak256("IntentSettlementForwarded(bytes,uint256,uint256,address,uint256,uint256)");
+            bytes32 eventSig = keccak256(
+                "IntentSettlementForwarded(bytes,uint256,uint256,address,uint256,uint256)"
+            );
             if (entries[i].topics[0] == eventSig) {
                 foundEvent = true;
 
                 // Decode event data
-                (address zrc20, uint256 eventAmount, uint256 eventTip) =
-                    abi.decode(entries[i].data, (address, uint256, uint256));
+                (address zrc20, uint256 eventAmount, uint256 eventTip) = abi
+                    .decode(entries[i].data, (address, uint256, uint256));
 
                 // Verify event parameters
-                assertEq(zrc20, address(inputToken), "ZRC20 address in event doesn't match");
-                assertEq(eventAmount, amount + tip, "Amount in event doesn't match");
+                assertEq(
+                    zrc20,
+                    address(inputToken),
+                    "ZRC20 address in event doesn't match"
+                );
+                assertEq(
+                    eventAmount,
+                    amount + tip,
+                    "Amount in event doesn't match"
+                );
                 // For ZetaChain destinations, only slippage is deducted from the tip (5% of 110 ether = 5.5 ether)
                 // So the remaining tip should be 10 - 5.5 = 4.5 ether
                 assertEq(eventTip, 4.5 ether, "Tip in event doesn't match");
@@ -1091,15 +1366,30 @@ contract RouterTest is Test {
         assertTrue(foundEvent, "IntentSettlementForwarded event not found");
 
         // Verify the mock Intent contract was called with the settlement payload
-        assertTrue(mockZetaChainIntent.wasCalled(), "Intent contract's onCall was not called");
-        assertEq(mockZetaChainIntent.lastCaller(), address(router), "Intent caller should be the router");
+        assertTrue(
+            mockZetaChainIntent.wasCalled(),
+            "Intent contract's onCall was not called"
+        );
+        assertEq(
+            mockZetaChainIntent.lastCaller(),
+            address(router),
+            "Intent caller should be the router"
+        );
 
         // Decode the settlement payload to verify its contents
-        PayloadUtils.SettlementPayload memory settlementPayload =
-            PayloadUtils.decodeSettlementPayload(mockZetaChainIntent.lastMessage());
+        PayloadUtils.SettlementPayload memory settlementPayload = PayloadUtils
+            .decodeSettlementPayload(mockZetaChainIntent.lastMessage());
 
-        assertEq(settlementPayload.intentId, intentId, "Intent ID in settlement payload doesn't match");
-        assertEq(settlementPayload.asset, targetAsset, "Asset in settlement payload doesn't match");
+        assertEq(
+            settlementPayload.intentId,
+            intentId,
+            "Intent ID in settlement payload doesn't match"
+        );
+        assertEq(
+            settlementPayload.asset,
+            targetAsset,
+            "Asset in settlement payload doesn't match"
+        );
         assertEq(
             settlementPayload.receiver,
             PayloadUtils.bytesToAddress(receiver),
@@ -1248,8 +1538,18 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
-        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
+        router.addTokenAssociation(
+            tokenName,
+            sourceChainId,
+            inputAsset,
+            address(inputToken)
+        );
+        router.addTokenAssociation(
+            tokenName,
+            targetChainId,
+            targetAsset,
+            address(targetZRC20)
+        );
 
         // Set a custom gas limit for the target chain
         uint256 customGasLimit = 500000;
@@ -1261,8 +1561,16 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes =
-            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
+        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
+            intentId,
+            amount,
+            tip,
+            targetChainId,
+            receiver,
+            false,
+            "",
+            0
+        );
 
         // Set modest slippage (5%)
         swapModule.setSlippage(500);
@@ -1271,7 +1579,10 @@ contract RouterTest is Test {
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, customGasLimit),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                customGasLimit
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1281,15 +1592,21 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
+        router.onCall(
+            context,
+            address(inputToken),
+            amount + tip,
+            intentPayloadBytes
+        );
 
         // The test passes if the mock call with the custom gas limit is used
         // No need for additional assertions as the mock would fail if the wrong gas limit was used
@@ -1311,8 +1628,18 @@ contract RouterTest is Test {
         address targetAsset = makeAddr("target_asset");
 
         // The key difference: using the same ZRC20 token for both source and target
-        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
-        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(inputToken));
+        router.addTokenAssociation(
+            tokenName,
+            sourceChainId,
+            inputAsset,
+            address(inputToken)
+        );
+        router.addTokenAssociation(
+            tokenName,
+            targetChainId,
+            targetAsset,
+            address(inputToken)
+        );
 
         // Setup intent payload
         bytes32 intentId = keccak256("test-intent");
@@ -1320,14 +1647,25 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes =
-            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
+        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
+            intentId,
+            amount,
+            tip,
+            targetChainId,
+            receiver,
+            false,
+            "",
+            0
+        );
 
         // Mock setup for IZRC20 withdrawGasFeeWithGasLimit
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(inputToken),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                router.withdrawGasLimit()
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1341,11 +1679,12 @@ contract RouterTest is Test {
         vm.record();
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
 
         // Check event is emitted with correct values
         vm.expectEmit();
@@ -1360,31 +1699,48 @@ contract RouterTest is Test {
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
+        router.onCall(
+            context,
+            address(inputToken),
+            amount + tip,
+            intentPayloadBytes
+        );
 
         // Verify the swap function was not called
-        (bytes32[] memory reads, bytes32[] memory writes) = vm.accesses(address(swapModule));
+        (bytes32[] memory reads, bytes32[] memory writes) = vm.accesses(
+            address(swapModule)
+        );
 
         // Verify no swap was performed - the swap function should not be called
         bool swapCalled = false;
-        bytes4 swapSelector = bytes4(keccak256("swap(address,address,uint256,address,uint256,string)"));
+        bytes4 swapSelector = bytes4(
+            keccak256("swap(address,address,uint256,address,uint256,string)")
+        );
 
         for (uint256 i = 0; i < reads.length; i++) {
             // Check if any read access matches the swap selector storage slot
-            if (uint256(reads[i]) < 4 && bytes4(uint32(uint256(reads[i]))) == swapSelector) {
+            if (
+                uint256(reads[i]) < 4 &&
+                bytes4(uint32(uint256(reads[i]))) == swapSelector
+            ) {
                 swapCalled = true;
                 break;
             }
         }
 
-        assertFalse(swapCalled, "Swap function should not be called when source and target ZRC20s are the same");
+        assertFalse(
+            swapCalled,
+            "Swap function should not be called when source and target ZRC20s are the same"
+        );
 
         // Verify approvals were made to the gateway
         assertTrue(
-            inputToken.allowance(address(router), address(gateway)) > 0, "Router should approve input token to gateway"
+            inputToken.allowance(address(router), address(gateway)) > 0,
+            "Router should approve input token to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(router), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(router), address(gateway)) > 0,
+            "Router should approve gas ZRC20 to gateway"
         );
 
         // Verify actual amount equals wanted amount (no reduction)
@@ -1392,7 +1748,7 @@ contract RouterTest is Test {
         // even better with an explicit check of the settlement payload
     }
 
-    function test_OnCall_InvalidSwapAmountOut() public {
+    function test_OnCall_SwapSurplusHandling() public {
         // Setup intent contract
         uint256 sourceChainId = 1;
         uint256 targetChainId = 2;
@@ -1406,8 +1762,18 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
-        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
+        router.addTokenAssociation(
+            tokenName,
+            sourceChainId,
+            inputAsset,
+            address(inputToken)
+        );
+        router.addTokenAssociation(
+            tokenName,
+            targetChainId,
+            targetAsset,
+            address(targetZRC20)
+        );
 
         // Setup intent payload
         bytes32 intentId = keccak256("test-intent");
@@ -1415,20 +1781,31 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes =
-            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
+        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
+            intentId,
+            amount,
+            tip,
+            targetChainId,
+            receiver,
+            false,
+            "",
+            0
+        );
 
         // Set modest slippage (5%)
         swapModule.setSlippage(500);
 
-        // Set a custom amount out for testing that is more than the wanted amount
+        // Set a custom amount out for testing that is more than the wanted amount (surplus)
         swapModule.setCustomAmountOut(amount + tip + 1 ether);
 
         // Mock setup for IZRC20 withdrawGasFeeWithGasLimit
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                router.withdrawGasLimit()
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1440,16 +1817,23 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
 
-        // Call onCall
+        // Call onCall - should succeed even with surplus
         vm.prank(address(gateway));
-        vm.expectRevert("Swap returned invalid amount");
-        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
+        router.onCall(
+            context,
+            address(inputToken),
+            amount + tip,
+            intentPayloadBytes
+        );
+
+        // Test passes if no revert occurs - surplus is handled gracefully
     }
 
     function test_OnCall_UsesCustomGasLimitFromPayload() public {
@@ -1466,8 +1850,18 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
-        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
+        router.addTokenAssociation(
+            tokenName,
+            sourceChainId,
+            inputAsset,
+            address(inputToken)
+        );
+        router.addTokenAssociation(
+            tokenName,
+            targetChainId,
+            targetAsset,
+            address(targetZRC20)
+        );
 
         // Set a custom gas limit for the target chain
         uint256 chainSpecificGasLimit = 500000;
@@ -1480,14 +1874,25 @@ contract RouterTest is Test {
         bytes memory receiver = abi.encodePacked(user2);
         uint256 customGasLimit = 700000; // Custom gas limit different from chain config
 
-        bytes memory intentPayloadBytes =
-            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", customGasLimit);
+        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
+            intentId,
+            amount,
+            tip,
+            targetChainId,
+            receiver,
+            false,
+            "",
+            customGasLimit
+        );
 
         // Mock withdrawGasFeeWithGasLimit to verify it's called with the custom gas limit from payload
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, customGasLimit),
+            abi.encodeWithSelector(
+                IZRC20.withdrawGasFeeWithGasLimit.selector,
+                customGasLimit
+            ),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1497,15 +1902,21 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
-            chainID: sourceChainId,
-            sender: abi.encodePacked(sourceIntentContract),
-            senderEVM: sourceIntentContract
-        });
+        IGateway.ZetaChainMessageContext memory context = IGateway
+            .ZetaChainMessageContext({
+                chainID: sourceChainId,
+                sender: abi.encodePacked(sourceIntentContract),
+                senderEVM: sourceIntentContract
+            });
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
+        router.onCall(
+            context,
+            address(inputToken),
+            amount + tip,
+            intentPayloadBytes
+        );
 
         // The test passes if the mock call with the custom gas limit is used
         // If the chain-specific gas limit was used instead, the mock would not match and the test would fail

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -30,23 +30,10 @@ contract RouterTest is Test {
     address public user1;
     address public user2;
 
-    event IntentContractSet(
-        uint256 indexed chainId,
-        address indexed intentContract
-    );
+    event IntentContractSet(uint256 indexed chainId, address indexed intentContract);
     event TokenAdded(string indexed name);
-    event TokenAssociationAdded(
-        string indexed name,
-        uint256 indexed chainId,
-        address asset,
-        address zrc20
-    );
-    event TokenAssociationUpdated(
-        string indexed name,
-        uint256 indexed chainId,
-        address asset,
-        address zrc20
-    );
+    event TokenAssociationAdded(string indexed name, uint256 indexed chainId, address asset, address zrc20);
+    event TokenAssociationUpdated(string indexed name, uint256 indexed chainId, address asset, address zrc20);
     event TokenAssociationRemoved(string indexed name, uint256 indexed chainId);
     event IntentSettlementForwarded(
         bytes indexed sender,
@@ -64,25 +51,15 @@ contract RouterTest is Test {
     event ChainWithdrawGasLimitRemoved(uint256 indexed chainId);
 
     // Helper function to create a properly initialized Router
-    function createInitializedRouter(
-        address gatewayAddr,
-        address swapModuleAddr
-    ) internal returns (Router) {
+    function createInitializedRouter(address gatewayAddr, address swapModuleAddr) internal returns (Router) {
         // Deploy implementation
         Router implementation = new Router();
 
         // Prepare initialization data
-        bytes memory initData = abi.encodeWithSelector(
-            Router.initialize.selector,
-            gatewayAddr,
-            swapModuleAddr
-        );
+        bytes memory initData = abi.encodeWithSelector(Router.initialize.selector, gatewayAddr, swapModuleAddr);
 
         // Deploy proxy
-        ERC1967Proxy proxy = new ERC1967Proxy(
-            address(implementation),
-            initData
-        );
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), initData);
 
         return Router(address(proxy));
     }
@@ -106,11 +83,7 @@ contract RouterTest is Test {
 
     // Helper function to create a router with the fixed output swap module
     function createFixedOutputRouter() internal returns (Router) {
-        return
-            createInitializedRouter(
-                address(gateway),
-                address(fixedOutputSwapModule)
-            );
+        return createInitializedRouter(address(gateway), address(fixedOutputSwapModule));
     }
 
     // Helper function for access control error expectations
@@ -118,13 +91,7 @@ contract RouterTest is Test {
         bytes32 role = 0x00; // DEFAULT_ADMIN_ROLE
         vm.expectRevert(
             abi.encodeWithSelector(
-                bytes4(
-                    keccak256(
-                        "AccessControlUnauthorizedAccount(address,bytes32)"
-                    )
-                ),
-                account,
-                role
+                bytes4(keccak256("AccessControlUnauthorizedAccount(address,bytes32)")), account, role
             )
         );
     }
@@ -224,11 +191,8 @@ contract RouterTest is Test {
         emit TokenAssociationAdded(name, chainId, asset, zrc20);
         router.addTokenAssociation(name, chainId, asset, zrc20);
 
-        (
-            address returnedAsset,
-            address returnedZrc20,
-            uint256 chainIdValue
-        ) = router.getTokenAssociation(zrc20, chainId);
+        (address returnedAsset, address returnedZrc20, uint256 chainIdValue) =
+            router.getTokenAssociation(zrc20, chainId);
         assertEq(returnedAsset, asset);
         assertEq(returnedZrc20, zrc20);
         assertEq(chainIdValue, chainId);
@@ -295,19 +259,14 @@ contract RouterTest is Test {
         emit TokenAssociationUpdated(name, chainId, asset2, zrc20);
         router.updateTokenAssociation(name, chainId, asset2, zrc20);
 
-        (
-            address returnedAsset,
-            address returnedZrc20,
-            uint256 chainIdValue
-        ) = router.getTokenAssociation(zrc20, chainId);
+        (address returnedAsset, address returnedZrc20, uint256 chainIdValue) =
+            router.getTokenAssociation(zrc20, chainId);
         assertEq(returnedAsset, asset2);
         assertEq(returnedZrc20, zrc20);
         assertEq(chainIdValue, chainId);
     }
 
-    function test_UpdateTokenAssociation_NonExistentAssociationReverts()
-        public
-    {
+    function test_UpdateTokenAssociation_NonExistentAssociationReverts() public {
         string memory name = "USDC";
         uint256 chainId = 1;
         address asset = makeAddr("asset");
@@ -349,9 +308,7 @@ contract RouterTest is Test {
         router.getTokenAssociation(zrc20, chainId);
     }
 
-    function test_RemoveTokenAssociation_NonExistentAssociationReverts()
-        public
-    {
+    function test_RemoveTokenAssociation_NonExistentAssociationReverts() public {
         string memory name = "USDC";
         uint256 chainId = 1;
 
@@ -386,11 +343,8 @@ contract RouterTest is Test {
         router.addTokenAssociation(name, chainId1, asset1, zrc20);
         router.addTokenAssociation(name, chainId2, asset2, zrc20);
 
-        (
-            uint256[] memory chainIds,
-            address[] memory assets,
-            address[] memory zrc20s
-        ) = router.getTokenAssociations(name);
+        (uint256[] memory chainIds, address[] memory assets, address[] memory zrc20s) =
+            router.getTokenAssociations(name);
         assertEq(chainIds.length, 2);
         assertEq(chainIds[0], chainId1);
         assertEq(chainIds[1], chainId2);
@@ -427,18 +381,8 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(
-            tokenName,
-            sourceChainId,
-            inputAsset,
-            address(inputToken)
-        );
-        router.addTokenAssociation(
-            tokenName,
-            targetChainId,
-            targetAsset,
-            address(targetZRC20)
-        );
+        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
+        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
 
         // Setup intent payload
         bytes32 intentId = keccak256("test-intent");
@@ -446,16 +390,8 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
-            intentId,
-            amount,
-            tip,
-            targetChainId,
-            receiver,
-            false,
-            "",
-            0
-        );
+        bytes memory intentPayloadBytes =
+            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
 
         // Set modest slippage (5%)
         swapModule.setSlippage(500);
@@ -464,10 +400,7 @@ contract RouterTest is Test {
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                router.withdrawGasLimit()
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -479,21 +412,15 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(
-            context,
-            address(inputToken),
-            amount + tip,
-            intentPayloadBytes
-        );
+        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
 
         // Verify approvals were made to the gateway
         assertTrue(
@@ -501,8 +428,7 @@ contract RouterTest is Test {
             "Router should approve target ZRC20 to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(router), address(gateway)) > 0,
-            "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(router), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
         );
     }
 
@@ -520,18 +446,8 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(
-            tokenName,
-            sourceChainId,
-            inputAsset,
-            address(inputToken)
-        );
-        router.addTokenAssociation(
-            tokenName,
-            targetChainId,
-            targetAsset,
-            address(targetZRC20)
-        );
+        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
+        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
 
         // Setup intent payload with a very small amount and tip
         bytes32 intentId = keccak256("test-intent");
@@ -558,10 +474,7 @@ contract RouterTest is Test {
         uint256 gasFee = 11 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                router.withdrawGasLimit()
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -571,12 +484,11 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
 
         // Call onCall and expect it to revert due to insufficient amount
         // - We're passing in 100 ether but the slippage will be 10 ether (10%)
@@ -655,18 +567,8 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(
-            tokenName,
-            sourceChainId,
-            inputAsset,
-            address(inputToken)
-        );
-        router.addTokenAssociation(
-            tokenName,
-            targetChainId,
-            targetAsset,
-            address(targetZRC20)
-        );
+        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
+        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
 
         // Setup intent payload with amount and small tip
         bytes32 intentId = keccak256("test-intent");
@@ -674,16 +576,8 @@ contract RouterTest is Test {
         uint256 tip = 3 ether; // Small tip that won't cover all costs
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
-            intentId,
-            amount,
-            tip,
-            targetChainId,
-            receiver,
-            false,
-            "",
-            0
-        );
+        bytes memory intentPayloadBytes =
+            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
 
         // Set high slippage (8%) so we can observe amount reduction
         swapModule.setSlippage(800); // 8% slippage = 8 ether on 100 ether
@@ -692,10 +586,7 @@ contract RouterTest is Test {
         uint256 gasFee = 2 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                router.withdrawGasLimit()
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -711,12 +602,11 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
 
         // Check that we correctly set the event expectations BEFORE the call
         // Event expectations must be set before the call that emits them
@@ -732,12 +622,7 @@ contract RouterTest is Test {
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(
-            context,
-            address(inputToken),
-            amount + tip,
-            intentPayloadBytes
-        );
+        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
 
         // Verify approvals to the gateway
         assertTrue(
@@ -745,8 +630,7 @@ contract RouterTest is Test {
             "Router should approve target ZRC20 to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(router), address(gateway)) > 0,
-            "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(router), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
         );
 
         // At this point we've confirmed:
@@ -773,18 +657,8 @@ contract RouterTest is Test {
         fixedRouter.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        fixedRouter.addTokenAssociation(
-            tokenName,
-            sourceChainId,
-            inputAsset,
-            address(inputToken)
-        );
-        fixedRouter.addTokenAssociation(
-            tokenName,
-            targetChainId,
-            targetAsset,
-            address(targetZRC20)
-        );
+        fixedRouter.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
+        fixedRouter.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
 
         // Setup intent payload
         bytes32 intentId = keccak256("test-intent");
@@ -792,36 +666,19 @@ contract RouterTest is Test {
         uint256 tip = 10 * 10 ** 6; // 10 USDC with 6 decimals
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
-            intentId,
-            amount,
-            tip,
-            targetChainId,
-            receiver,
-            false,
-            "",
-            0
-        );
+        bytes memory intentPayloadBytes =
+            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
 
         // Mock decimals for input token (6 decimals like USDC)
-        vm.mockCall(
-            address(inputToken),
-            abi.encodeWithSelector(IZRC20.decimals.selector),
-            abi.encode(uint8(6))
-        );
+        vm.mockCall(address(inputToken), abi.encodeWithSelector(IZRC20.decimals.selector), abi.encode(uint8(6)));
 
         // Mock decimals for target token (18 decimals like most tokens)
-        vm.mockCall(
-            address(targetZRC20),
-            abi.encodeWithSelector(IZRC20.decimals.selector),
-            abi.encode(uint8(18))
-        );
+        vm.mockCall(address(targetZRC20), abi.encodeWithSelector(IZRC20.decimals.selector), abi.encode(uint8(18)));
 
         // Calculate the expected amount in target decimals
         uint256 expectedAmountInTargetDecimals = amount * 10 ** 12; // 100e6 * 10^12 = 100e18
         uint256 expectedTipInTargetDecimals = tip * 10 ** 12; // 10e6 * 10^12 = 10e18
-        uint256 expectedTotal = expectedAmountInTargetDecimals +
-            expectedTipInTargetDecimals;
+        uint256 expectedTotal = expectedAmountInTargetDecimals + expectedTipInTargetDecimals;
 
         // Set a fixed output amount that's slightly less than the converted total
         // This simulates some slippage
@@ -831,10 +688,7 @@ contract RouterTest is Test {
         uint256 gasFee = 1 ether; // 1 token with 18 decimals for gas fee
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                fixedRouter.withdrawGasLimit()
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, fixedRouter.withdrawGasLimit()),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -844,12 +698,11 @@ contract RouterTest is Test {
         gasZRC20.mint(address(fixedOutputSwapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
 
         // Check event is emitted with correct values - tip should be slightly reduced due to slippage
         vm.expectEmit();
@@ -864,12 +717,7 @@ contract RouterTest is Test {
 
         // Call onCall
         vm.prank(address(gateway));
-        fixedRouter.onCall(
-            context,
-            address(inputToken),
-            amount + tip,
-            intentPayloadBytes
-        );
+        fixedRouter.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
 
         // Verify approvals were made to the gateway
         assertTrue(
@@ -877,8 +725,7 @@ contract RouterTest is Test {
             "Router should approve target ZRC20 to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(fixedRouter), address(gateway)) > 0,
-            "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(fixedRouter), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
         );
     }
 
@@ -923,35 +770,20 @@ contract RouterTest is Test {
         assertFalse(router.paused(), "Router should not be paused initially");
 
         // Test that someone with PAUSER_ROLE can pause
-        assertTrue(
-            router.hasRole(router.PAUSER_ROLE(), address(this)),
-            "Test contract should have PAUSER_ROLE"
-        );
+        assertTrue(router.hasRole(router.PAUSER_ROLE(), address(this)), "Test contract should have PAUSER_ROLE");
         router.pause();
-        assertTrue(
-            router.paused(),
-            "Router should be paused after calling pause()"
-        );
+        assertTrue(router.paused(), "Router should be paused after calling pause()");
 
         // Test that someone with DEFAULT_ADMIN_ROLE can unpause
-        assertTrue(
-            router.hasRole(0x00, address(this)),
-            "Test contract should have DEFAULT_ADMIN_ROLE"
-        );
+        assertTrue(router.hasRole(0x00, address(this)), "Test contract should have DEFAULT_ADMIN_ROLE");
         router.unpause();
-        assertFalse(
-            router.paused(),
-            "Router should not be paused after calling unpause()"
-        );
+        assertFalse(router.paused(), "Router should not be paused after calling unpause()");
     }
 
     function test_RevertWhen_NonPauserTriesToPause() public {
         // Make sure user1 doesn't have PAUSER_ROLE
         bytes32 pauserRole = router.PAUSER_ROLE();
-        assertFalse(
-            router.hasRole(pauserRole, user1),
-            "User1 should not have PAUSER_ROLE"
-        );
+        assertFalse(router.hasRole(pauserRole, user1), "User1 should not have PAUSER_ROLE");
 
         // Set up the prank
         vm.prank(user1);
@@ -968,10 +800,7 @@ contract RouterTest is Test {
         }
 
         // Verify that the call reverted
-        assertTrue(
-            hasReverted,
-            "Call to pause() should revert when called by non-pauser"
-        );
+        assertTrue(hasReverted, "Call to pause() should revert when called by non-pauser");
 
         // Verify that the router is still not paused
         assertFalse(router.paused(), "Router should not be paused");
@@ -984,10 +813,7 @@ contract RouterTest is Test {
 
         // Make sure user1 doesn't have DEFAULT_ADMIN_ROLE
         bytes32 adminRole = 0x00; // DEFAULT_ADMIN_ROLE
-        assertFalse(
-            router.hasRole(adminRole, user1),
-            "User1 should not have DEFAULT_ADMIN_ROLE"
-        );
+        assertFalse(router.hasRole(adminRole, user1), "User1 should not have DEFAULT_ADMIN_ROLE");
 
         // Set up the prank
         vm.prank(user1);
@@ -1004,10 +830,7 @@ contract RouterTest is Test {
         }
 
         // Verify that the call reverted
-        assertTrue(
-            hasReverted,
-            "Call to unpause() should revert when called by non-admin"
-        );
+        assertTrue(hasReverted, "Call to unpause() should revert when called by non-admin");
 
         // Verify that the router is still paused
         assertTrue(router.paused(), "Router should still be paused");
@@ -1020,12 +843,11 @@ contract RouterTest is Test {
         router.setIntentContract(sourceChainId, sourceIntentContract);
 
         // Setup context and a dummy payload
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
         bytes memory dummyPayload = new bytes(0);
 
         // Pause the router
@@ -1047,10 +869,7 @@ contract RouterTest is Test {
         }
 
         // Verify that the call reverted
-        assertTrue(
-            hasReverted,
-            "Call to onCall() should revert when router is paused"
-        );
+        assertTrue(hasReverted, "Call to onCall() should revert when router is paused");
     }
 
     function test_RouterUpgrade() public {
@@ -1069,30 +888,14 @@ contract RouterTest is Test {
         router.upgradeToAndCall(address(newImplementation), "");
 
         // Verify that storage was preserved after upgrade
-        assertEq(
-            router.gateway(),
-            originalGateway,
-            "Gateway address should be preserved after upgrade"
-        );
-        assertEq(
-            router.swapModule(),
-            originalSwapModule,
-            "Swap module address should be preserved after upgrade"
-        );
-        assertEq(
-            router.withdrawGasLimit(),
-            originalGasLimit,
-            "Withdraw gas limit should be preserved after upgrade"
-        );
+        assertEq(router.gateway(), originalGateway, "Gateway address should be preserved after upgrade");
+        assertEq(router.swapModule(), originalSwapModule, "Swap module address should be preserved after upgrade");
+        assertEq(router.withdrawGasLimit(), originalGasLimit, "Withdraw gas limit should be preserved after upgrade");
 
         // Verify that we can still call functions on the upgraded router
         uint256 newGasLimit = originalGasLimit + 100000;
         router.setWithdrawGasLimit(newGasLimit);
-        assertEq(
-            router.withdrawGasLimit(),
-            newGasLimit,
-            "Should be able to set new values after upgrade"
-        );
+        assertEq(router.withdrawGasLimit(), newGasLimit, "Should be able to set new values after upgrade");
     }
 
     function test_RouterUpgrade_OnlyAdminCanUpgrade() public {
@@ -1111,10 +914,7 @@ contract RouterTest is Test {
         uint256 targetChainId = 2;
         address zetaChainIntentContract = makeAddr("zetaChainIntentContract");
         router.setIntentContract(zetaChainId, zetaChainIntentContract);
-        router.setIntentContract(
-            targetChainId,
-            makeAddr("targetIntentContract")
-        );
+        router.setIntentContract(targetChainId, makeAddr("targetIntentContract"));
 
         // Setup token associations for both source and target chains
         string memory tokenName = "USDC";
@@ -1122,46 +922,25 @@ contract RouterTest is Test {
 
         // Add token association for the source chain (ZetaChain)
         address sourceAsset = address(inputToken); // Use inputToken as the source asset
-        router.addTokenAssociation(
-            tokenName,
-            zetaChainId,
-            sourceAsset,
-            address(inputToken)
-        );
+        router.addTokenAssociation(tokenName, zetaChainId, sourceAsset, address(inputToken));
 
         // Add token association for the target chain
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(
-            tokenName,
-            targetChainId,
-            targetAsset,
-            address(targetZRC20)
-        );
+        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
 
         // Create intent payload
         bytes32 intentId = keccak256("zetachain-intent-test");
         uint256 amount = 100 ether;
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
-        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
-            intentId,
-            amount,
-            tip,
-            targetChainId,
-            receiver,
-            false,
-            "",
-            0
-        );
+        bytes memory intentPayloadBytes =
+            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
 
         // Mock setup for withdrawGasFeeWithGasLimit
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                router.withdrawGasLimit()
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1173,24 +952,18 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context to simulate call from ZetaChain Intent
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: zetaChainId,
-                sender: abi.encodePacked(zetaChainIntentContract),
-                senderEVM: zetaChainIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: zetaChainId,
+            sender: abi.encodePacked(zetaChainIntentContract),
+            senderEVM: zetaChainIntentContract
+        });
 
         // Start recording logs to verify events
         vm.recordLogs();
 
         // Call onCall as if from the Intent contract on ZetaChain
         vm.prank(address(gateway));
-        router.onCall(
-            context,
-            address(inputToken),
-            amount + tip,
-            intentPayloadBytes
-        );
+        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
 
         // Verify approval to gateway was made
         assertTrue(
@@ -1198,8 +971,7 @@ contract RouterTest is Test {
             "Router should approve target ZRC20 to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(router), address(gateway)) > 0,
-            "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(router), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
         );
 
         // Verify IntentSettlementForwarded event was emitted with correct parameters
@@ -1208,27 +980,17 @@ contract RouterTest is Test {
 
         for (uint256 i = 0; i < entries.length; i++) {
             // The event signature for IntentSettlementForwarded
-            bytes32 eventSig = keccak256(
-                "IntentSettlementForwarded(bytes,uint256,uint256,address,uint256,uint256)"
-            );
+            bytes32 eventSig = keccak256("IntentSettlementForwarded(bytes,uint256,uint256,address,uint256,uint256)");
             if (entries[i].topics[0] == eventSig) {
                 foundEvent = true;
 
                 // Decode the non-indexed parameters
-                (address zrc20, uint256 eventAmount, uint256 eventTip) = abi
-                    .decode(entries[i].data, (address, uint256, uint256));
+                (address zrc20, uint256 eventAmount, uint256 eventTip) =
+                    abi.decode(entries[i].data, (address, uint256, uint256));
 
                 // Verify the event parameters
-                assertEq(
-                    zrc20,
-                    address(inputToken),
-                    "ZRC20 address in event doesn't match"
-                );
-                assertEq(
-                    eventAmount,
-                    amount + tip,
-                    "Amount in event doesn't match"
-                ); // The event reports the total amount including tip
+                assertEq(zrc20, address(inputToken), "ZRC20 address in event doesn't match");
+                assertEq(eventAmount, amount + tip, "Amount in event doesn't match"); // The event reports the total amount including tip
                 assertEq(eventTip, 9 ether, "Tip in event doesn't match"); // Actual tip in the event is 9 ether (1 ether is used for gas)
             }
         }
@@ -1256,18 +1018,8 @@ contract RouterTest is Test {
         address targetAsset = makeAddr("target_asset");
 
         // Add token associations for source chain and ZetaChain
-        router.addTokenAssociation(
-            tokenName,
-            sourceChainId,
-            inputAsset,
-            address(inputToken)
-        );
-        router.addTokenAssociation(
-            tokenName,
-            zetaChainId,
-            targetAsset,
-            address(targetZRC20)
-        );
+        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
+        router.addTokenAssociation(tokenName, zetaChainId, targetAsset, address(targetZRC20));
 
         // Setup intent payload with ZetaChain as the target
         bytes32 intentId = keccak256("zetachain-target-test");
@@ -1275,16 +1027,8 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
-            intentId,
-            amount,
-            tip,
-            zetaChainId,
-            receiver,
-            false,
-            "",
-            0
-        );
+        bytes memory intentPayloadBytes =
+            PayloadUtils.encodeIntentPayload(intentId, amount, tip, zetaChainId, receiver, false, "", 0);
 
         // Set modest slippage (5%)
         swapModule.setSlippage(500);
@@ -1294,10 +1038,7 @@ contract RouterTest is Test {
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                router.withdrawGasLimit()
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1312,51 +1053,35 @@ contract RouterTest is Test {
         gasZRC20.mint(address(router), gasFee);
 
         // Setup context for the source chain
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
 
         // Start recording logs to verify events
         vm.recordLogs();
 
         // Call onCall - this should directly call the Intent contract instead of using the gateway
         vm.prank(address(gateway));
-        router.onCall(
-            context,
-            address(inputToken),
-            amount + tip,
-            intentPayloadBytes
-        );
+        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
 
         // Verify IntentSettlementForwarded event was emitted
         Vm.Log[] memory entries = vm.getRecordedLogs();
         bool foundEvent = false;
 
         for (uint256 i = 0; i < entries.length; i++) {
-            bytes32 eventSig = keccak256(
-                "IntentSettlementForwarded(bytes,uint256,uint256,address,uint256,uint256)"
-            );
+            bytes32 eventSig = keccak256("IntentSettlementForwarded(bytes,uint256,uint256,address,uint256,uint256)");
             if (entries[i].topics[0] == eventSig) {
                 foundEvent = true;
 
                 // Decode event data
-                (address zrc20, uint256 eventAmount, uint256 eventTip) = abi
-                    .decode(entries[i].data, (address, uint256, uint256));
+                (address zrc20, uint256 eventAmount, uint256 eventTip) =
+                    abi.decode(entries[i].data, (address, uint256, uint256));
 
                 // Verify event parameters
-                assertEq(
-                    zrc20,
-                    address(inputToken),
-                    "ZRC20 address in event doesn't match"
-                );
-                assertEq(
-                    eventAmount,
-                    amount + tip,
-                    "Amount in event doesn't match"
-                );
+                assertEq(zrc20, address(inputToken), "ZRC20 address in event doesn't match");
+                assertEq(eventAmount, amount + tip, "Amount in event doesn't match");
                 // For ZetaChain destinations, only slippage is deducted from the tip (5% of 110 ether = 5.5 ether)
                 // So the remaining tip should be 10 - 5.5 = 4.5 ether
                 assertEq(eventTip, 4.5 ether, "Tip in event doesn't match");
@@ -1366,30 +1091,15 @@ contract RouterTest is Test {
         assertTrue(foundEvent, "IntentSettlementForwarded event not found");
 
         // Verify the mock Intent contract was called with the settlement payload
-        assertTrue(
-            mockZetaChainIntent.wasCalled(),
-            "Intent contract's onCall was not called"
-        );
-        assertEq(
-            mockZetaChainIntent.lastCaller(),
-            address(router),
-            "Intent caller should be the router"
-        );
+        assertTrue(mockZetaChainIntent.wasCalled(), "Intent contract's onCall was not called");
+        assertEq(mockZetaChainIntent.lastCaller(), address(router), "Intent caller should be the router");
 
         // Decode the settlement payload to verify its contents
-        PayloadUtils.SettlementPayload memory settlementPayload = PayloadUtils
-            .decodeSettlementPayload(mockZetaChainIntent.lastMessage());
+        PayloadUtils.SettlementPayload memory settlementPayload =
+            PayloadUtils.decodeSettlementPayload(mockZetaChainIntent.lastMessage());
 
-        assertEq(
-            settlementPayload.intentId,
-            intentId,
-            "Intent ID in settlement payload doesn't match"
-        );
-        assertEq(
-            settlementPayload.asset,
-            targetAsset,
-            "Asset in settlement payload doesn't match"
-        );
+        assertEq(settlementPayload.intentId, intentId, "Intent ID in settlement payload doesn't match");
+        assertEq(settlementPayload.asset, targetAsset, "Asset in settlement payload doesn't match");
         assertEq(
             settlementPayload.receiver,
             PayloadUtils.bytesToAddress(receiver),
@@ -1538,18 +1248,8 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(
-            tokenName,
-            sourceChainId,
-            inputAsset,
-            address(inputToken)
-        );
-        router.addTokenAssociation(
-            tokenName,
-            targetChainId,
-            targetAsset,
-            address(targetZRC20)
-        );
+        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
+        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
 
         // Set a custom gas limit for the target chain
         uint256 customGasLimit = 500000;
@@ -1561,16 +1261,8 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
-            intentId,
-            amount,
-            tip,
-            targetChainId,
-            receiver,
-            false,
-            "",
-            0
-        );
+        bytes memory intentPayloadBytes =
+            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
 
         // Set modest slippage (5%)
         swapModule.setSlippage(500);
@@ -1579,10 +1271,7 @@ contract RouterTest is Test {
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                customGasLimit
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, customGasLimit),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1592,21 +1281,15 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(
-            context,
-            address(inputToken),
-            amount + tip,
-            intentPayloadBytes
-        );
+        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
 
         // The test passes if the mock call with the custom gas limit is used
         // No need for additional assertions as the mock would fail if the wrong gas limit was used
@@ -1628,18 +1311,8 @@ contract RouterTest is Test {
         address targetAsset = makeAddr("target_asset");
 
         // The key difference: using the same ZRC20 token for both source and target
-        router.addTokenAssociation(
-            tokenName,
-            sourceChainId,
-            inputAsset,
-            address(inputToken)
-        );
-        router.addTokenAssociation(
-            tokenName,
-            targetChainId,
-            targetAsset,
-            address(inputToken)
-        );
+        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
+        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(inputToken));
 
         // Setup intent payload
         bytes32 intentId = keccak256("test-intent");
@@ -1647,25 +1320,14 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
-            intentId,
-            amount,
-            tip,
-            targetChainId,
-            receiver,
-            false,
-            "",
-            0
-        );
+        bytes memory intentPayloadBytes =
+            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
 
         // Mock setup for IZRC20 withdrawGasFeeWithGasLimit
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(inputToken),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                router.withdrawGasLimit()
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1679,12 +1341,11 @@ contract RouterTest is Test {
         vm.record();
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
 
         // Check event is emitted with correct values
         vm.expectEmit();
@@ -1699,48 +1360,31 @@ contract RouterTest is Test {
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(
-            context,
-            address(inputToken),
-            amount + tip,
-            intentPayloadBytes
-        );
+        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
 
         // Verify the swap function was not called
-        (bytes32[] memory reads, bytes32[] memory writes) = vm.accesses(
-            address(swapModule)
-        );
+        (bytes32[] memory reads, bytes32[] memory writes) = vm.accesses(address(swapModule));
 
         // Verify no swap was performed - the swap function should not be called
         bool swapCalled = false;
-        bytes4 swapSelector = bytes4(
-            keccak256("swap(address,address,uint256,address,uint256,string)")
-        );
+        bytes4 swapSelector = bytes4(keccak256("swap(address,address,uint256,address,uint256,string)"));
 
         for (uint256 i = 0; i < reads.length; i++) {
             // Check if any read access matches the swap selector storage slot
-            if (
-                uint256(reads[i]) < 4 &&
-                bytes4(uint32(uint256(reads[i]))) == swapSelector
-            ) {
+            if (uint256(reads[i]) < 4 && bytes4(uint32(uint256(reads[i]))) == swapSelector) {
                 swapCalled = true;
                 break;
             }
         }
 
-        assertFalse(
-            swapCalled,
-            "Swap function should not be called when source and target ZRC20s are the same"
-        );
+        assertFalse(swapCalled, "Swap function should not be called when source and target ZRC20s are the same");
 
         // Verify approvals were made to the gateway
         assertTrue(
-            inputToken.allowance(address(router), address(gateway)) > 0,
-            "Router should approve input token to gateway"
+            inputToken.allowance(address(router), address(gateway)) > 0, "Router should approve input token to gateway"
         );
         assertTrue(
-            gasZRC20.allowance(address(router), address(gateway)) > 0,
-            "Router should approve gas ZRC20 to gateway"
+            gasZRC20.allowance(address(router), address(gateway)) > 0, "Router should approve gas ZRC20 to gateway"
         );
 
         // Verify actual amount equals wanted amount (no reduction)
@@ -1762,18 +1406,8 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(
-            tokenName,
-            sourceChainId,
-            inputAsset,
-            address(inputToken)
-        );
-        router.addTokenAssociation(
-            tokenName,
-            targetChainId,
-            targetAsset,
-            address(targetZRC20)
-        );
+        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
+        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
 
         // Setup intent payload
         bytes32 intentId = keccak256("test-intent");
@@ -1781,16 +1415,8 @@ contract RouterTest is Test {
         uint256 tip = 10 ether;
         bytes memory receiver = abi.encodePacked(user2);
 
-        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
-            intentId,
-            amount,
-            tip,
-            targetChainId,
-            receiver,
-            false,
-            "",
-            0
-        );
+        bytes memory intentPayloadBytes =
+            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", 0);
 
         // Set modest slippage (5%)
         swapModule.setSlippage(500);
@@ -1802,10 +1428,7 @@ contract RouterTest is Test {
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                router.withdrawGasLimit()
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, router.withdrawGasLimit()),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1817,21 +1440,15 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
 
         // Call onCall - should succeed even with surplus
         vm.prank(address(gateway));
-        router.onCall(
-            context,
-            address(inputToken),
-            amount + tip,
-            intentPayloadBytes
-        );
+        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
 
         // Test passes if no revert occurs - surplus is handled gracefully
     }
@@ -1850,18 +1467,8 @@ contract RouterTest is Test {
         router.addToken(tokenName);
         address inputAsset = makeAddr("input_asset");
         address targetAsset = makeAddr("target_asset");
-        router.addTokenAssociation(
-            tokenName,
-            sourceChainId,
-            inputAsset,
-            address(inputToken)
-        );
-        router.addTokenAssociation(
-            tokenName,
-            targetChainId,
-            targetAsset,
-            address(targetZRC20)
-        );
+        router.addTokenAssociation(tokenName, sourceChainId, inputAsset, address(inputToken));
+        router.addTokenAssociation(tokenName, targetChainId, targetAsset, address(targetZRC20));
 
         // Set a custom gas limit for the target chain
         uint256 chainSpecificGasLimit = 500000;
@@ -1874,25 +1481,14 @@ contract RouterTest is Test {
         bytes memory receiver = abi.encodePacked(user2);
         uint256 customGasLimit = 700000; // Custom gas limit different from chain config
 
-        bytes memory intentPayloadBytes = PayloadUtils.encodeIntentPayload(
-            intentId,
-            amount,
-            tip,
-            targetChainId,
-            receiver,
-            false,
-            "",
-            customGasLimit
-        );
+        bytes memory intentPayloadBytes =
+            PayloadUtils.encodeIntentPayload(intentId, amount, tip, targetChainId, receiver, false, "", customGasLimit);
 
         // Mock withdrawGasFeeWithGasLimit to verify it's called with the custom gas limit from payload
         uint256 gasFee = 1 ether;
         vm.mockCall(
             address(targetZRC20),
-            abi.encodeWithSelector(
-                IZRC20.withdrawGasFeeWithGasLimit.selector,
-                customGasLimit
-            ),
+            abi.encodeWithSelector(IZRC20.withdrawGasFeeWithGasLimit.selector, customGasLimit),
             abi.encode(address(gasZRC20), gasFee)
         );
 
@@ -1902,21 +1498,15 @@ contract RouterTest is Test {
         gasZRC20.mint(address(swapModule), gasFee);
 
         // Setup context
-        IGateway.ZetaChainMessageContext memory context = IGateway
-            .ZetaChainMessageContext({
-                chainID: sourceChainId,
-                sender: abi.encodePacked(sourceIntentContract),
-                senderEVM: sourceIntentContract
-            });
+        IGateway.ZetaChainMessageContext memory context = IGateway.ZetaChainMessageContext({
+            chainID: sourceChainId,
+            sender: abi.encodePacked(sourceIntentContract),
+            senderEVM: sourceIntentContract
+        });
 
         // Call onCall
         vm.prank(address(gateway));
-        router.onCall(
-            context,
-            address(inputToken),
-            amount + tip,
-            intentPayloadBytes
-        );
+        router.onCall(context, address(inputToken), amount + tip, intentPayloadBytes);
 
         // The test passes if the mock call with the custom gas limit is used
         // If the chain-specific gas limit was used instead, the mock would not match and the test would fail


### PR DESCRIPTION
Should address https://github.com/speedrun-hq/speedrun/issues/130

If the pool are not extensively arbitraged or for some other reason the output tokens can be higher than the input.

We initially had a check to revert if the output was bigger but this led the intent from not being settle.

Removing this check will prevent the intent routing from failing. We trust the swap module to return a correct value for the output.

Currently the surplus is assumed to be small enough to not be handled. We can optimize this in the future.